### PR TITLE
Makes C compiler configurable

### DIFF
--- a/src/MicroHs/Main.hs
+++ b/src/MicroHs/Main.hs
@@ -118,8 +118,9 @@ mainCompile mhsdir flags mn = do
        hClose h
        ct1 <- getTimeMilli
        mcc <- lookupEnv "MHSCC"
+       compiler <- fromMaybe "cc" <$> lookupEnv "CC"
        let conf = "unix-" ++ show _wordSize
-           cc = fromMaybe ("cc -w -Wall -O3 " ++ mhsdir ++ "/src/runtime/eval-" ++ conf ++ ".c " ++ " $IN -lm -o $OUT") mcc
+           cc = fromMaybe (compiler ++ " -w -Wall -O3 " ++ mhsdir ++ "/src/runtime/eval-" ++ conf ++ ".c " ++ " $IN -lm -o $OUT") mcc
            cmd = substString "$IN" fn $ substString "$OUT" outFile cc
        when (verbose flags > 0) $
          putStrLn $ "Execute: " ++ show cmd


### PR DESCRIPTION
Hi Lennart 👋🏼 

Very awesome project.

Not sure if supporting JS / WASM is a goal, but this should make it easier for `mhs` to use [emscripten](emscripten.org) to potentially support WASM runtimes, node.js and browsers as first class platforms (since the C seems very portable).

My thinking was that `$MHSCC` could remain and be used as a separate command for compilation (no changes to it), but `$CC` could be introduced and used to alter the C compiler in the default compilation pipeline (when `$MHSCC` is undefined).

Here's some example usage below (this was tested with both `make bootstrap` and `make newmhs`)

### Node 

```bash
$ make clean && make bootstrap 
$ CC='emcc -sALLOW_MEMORY_GROWTH -sSTACK_SIZE=5MB' ./bin/mhs -v Example -oexample.js && node example.js
....
Execute: "emcc -sALLOW_MEMORY_GROWTH -sSTACK_SIZE=5MB -w -Wall -O3 ./src/runtime/eval-unix-64.c  /var/folders/tz/gmnrpnw56vl1dwynrkzc78p40000gn/T//mhsc0000031734.c -lm -o example.js"
C compilation           5701ms
Some factorials
[1,2,6,3628800]
```

### Browser 

```bash
$ CC='emcc -sALLOW_MEMORY_GROWTH -sSTACK_SIZE=5MB' ./bin/mhs -v Example -oexample.html
$ simple-http-server .
```

<img width="821" alt="image" src="https://github.com/augustss/MicroHs/assets/875324/0d029299-f8c7-4785-b1e4-9ff299cb77ae">

Note:
  - The `-sALLOW_MEMORY_GROWTH -sSTACK_SIZE=5MB` was necessary to avoid a stack overflow error.
  - Had issues loading the generated WASM in [wasmer.io](https://wasmer.io/), could address that separately though.

