### PR TITLE
Adds emscripten Makefile and CI entries

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -118,3 +118,21 @@ jobs:
     - name: make nfib
       run: make CONF=unix-32 nfibtest
       shell: alpine.sh {0}
+
+  build-linux-emscripten:
+    runs-on: ubuntu-latest
+    steps:
+     - uses: actions/checkout@v3
+     - uses: mymindstorm/setup-emsdk@v13
+     - uses: actions/setup-node@v4
+     - name: run emscripten tests
+       run: make emscripten
+
+  build-macos-emscripten:
+    runs-on: macos-latest
+    steps:
+     - uses: actions/checkout@v3
+     - uses: mymindstorm/setup-emsdk@v13
+     - uses: actions/setup-node@v4
+     - name: run emscripten tests
+       run: make emscripten

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,11 @@ tmp/*
 a.out
 *.prof
 dist-newstyle/
+dist/
 .mhsi
 Interactive.hs
 generated/*
 .mhscache
+*.js
+*.wasm
+/tags

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,8 @@ cachelib:
 #
 clean:
 	rm -rf src/*/*.hi src/*/*.o *.comb *.tmp *~ bin/* a.out $(GHCOUTDIR) tmp/* Tools/*.o Tools/*.hi dist-newstyle generated/*-stage* cache
-	cd tests; make clean
+	make clean -f Makefile.emscripten;
+	cd tests; make clean;
 
 install:
 	mkdir -p $(PREFIX)/bin
@@ -132,3 +133,6 @@ cachetest:	bin/mhs bin/mhseval Example.hs
 
 nfibtest: bin/mhs bin/mhseval
 	bin/mhs -itests Nfib && bin/mhseval
+
+emscripten: bin/mhs
+	make test -f Makefile.emscripten;

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -1,0 +1,41 @@
+TMHS=./bin/mhs -itests
+CC=emcc -sALLOW_MEMORY_GROWTH -sSTACK_SIZE=5MB
+NODE=node
+CONF=unix-64
+.PHONY: test
+
+test:
+	CC='$(CC)' $(TMHS) Hello -otests/Hello.js && $(NODE) tests/Hello.js > tests/Hello.out && diff tests/Hello.ref tests/Hello.out
+	CC='$(CC)' $(TMHS) IOTest -otests/IOTest.js && (echo q | $(NODE) tests/IOTest.js a bb ccc | sed 's/^[0-9]*ms/1ms/' > tests/IOTest.out) && diff tests/IOTest.ref tests/IOTest.out
+	CC='$(CC)' $(TMHS) StringTest -otests/StringTest.js && $(NODE) tests/StringTest.js > tests/StringTest.out && diff tests/StringTest.ref tests/StringTest.out
+	CC='$(CC)' $(TMHS) ListTest -otests/ListTest.js && $(NODE) tests/ListTest.js > tests/ListTest.out && diff tests/ListTest.ref tests/ListTest.out
+	CC='$(CC)' $(TMHS) Fac -otests/Fac.js && $(NODE) tests/Fac.js > tests/Fac.out && diff tests/Fac.ref tests/Fac.out
+	CC='$(CC)' $(TMHS) Misc -otests/Misc.js && $(NODE) tests/Misc.js > tests/Misc.out && diff tests/Misc.ref tests/Misc.out
+	CC='$(CC)' $(TMHS) Case -otests/Case.js && $(NODE) tests/Case.js > tests/Case.out && diff tests/Case.ref tests/Case.out
+	CC='$(CC)' $(TMHS) Arith -otests/Arith.js && $(NODE) tests/Arith.js > tests/Arith.out && diff tests/Arith.ref tests/Arith.out
+	CC='$(CC)' $(TMHS) Guard -otests/Guard.js && $(NODE) tests/Guard.js > tests/Guard.out && diff tests/Guard.ref tests/Guard.out
+	CC='$(CC)' $(TMHS) Newtype -otests/Newtype.js && $(NODE) tests/Newtype.js > tests/Newtype.out && diff tests/Newtype.ref tests/Newtype.out
+	CC='$(CC)' $(TMHS) LitMatch -otests/LitMatch.js && $(NODE) tests/LitMatch.js > tests/LitMatch.out && diff tests/LitMatch.ref tests/LitMatch.out
+	CC='$(CC)' $(TMHS) Word -otests/Word.js && $(NODE) tests/Word.js > tests/Word.out && diff tests/Word.ref tests/Word.out
+	CC='$(CC)' $(TMHS) Enum -otests/Enum.js && $(NODE) tests/Enum.js > tests/Enum.out && diff tests/Enum.ref tests/Enum.out
+	# CC='$(CC)' $(TMHS) Foreign -otests/Foreign.js && $(NODE) tests/Foreign.js > tests/Foreign.out && diff tests/Foreign.ref tests/Foreign.out
+	CC='$(CC)' $(TMHS) MutRec -otests/MutRec.js && $(NODE) tests/MutRec.js > tests/MutRec.out && diff tests/MutRec.ref tests/MutRec.out
+	CC='$(CC)' $(TMHS) LocalPoly -otests/LocalPoly.js && $(NODE) tests/LocalPoly.js > tests/LocalPoly.out && diff tests/LocalPoly.ref tests/LocalPoly.out
+	CC='$(CC)' $(TMHS) Rank2 -otests/Rank2.js && $(NODE) tests/Rank2.js > tests/Rank2.out && diff tests/Rank2.ref tests/Rank2.out
+	CC='$(CC)' $(TMHS) Catch -otests/Catch.js && $(NODE) tests/Catch.js | sed 's/tests\/Catch.hs/.\/Catch.hs/' > tests/Catch.out && diff tests/Catch.ref tests/Catch.out
+	CC='$(CC)' $(TMHS) FArith -otests/FArith.js && $(NODE) tests/FArith.js > tests/FArith.out && diff tests/FArith.ref tests/FArith.out
+	CC='$(CC)' $(TMHS) Infix -otests/Infix.js && $(NODE) tests/Infix.js > tests/Infix.out && diff tests/Infix.ref tests/Infix.out
+	CC='$(CC)' $(TMHS) Class -otests/Class.js && $(NODE) tests/Class.js > tests/Class.out && diff tests/Class.ref tests/Class.out
+	CC='$(CC)' $(TMHS) Eq -otests/Eq.js && $(NODE) tests/Eq.js > tests/Eq.out && diff tests/Eq.ref tests/Eq.out
+	# CC='$(CC)' $(TMHS) Floating -otests/Floating.js && $(NODE) tests/Floating.js > tests/Floating.out && diff tests/Floating.ref tests/Floating.out
+	CC='$(CC)' $(TMHS) Default -otests/Default.js && $(NODE) tests/Default.js > tests/Default.out && diff tests/Default.ref tests/Default.out
+	CC='$(CC)' $(TMHS) Multi -otests/Multi.js && $(NODE) tests/Multi.js > tests/Multi.out && diff tests/Multi.ref tests/Multi.out
+	CC='$(CC)' $(TMHS) Exists -otests/Exists.js && $(NODE) tests/Exists.js > tests/Exists.out && diff tests/Exists.ref tests/Exists.out
+	CC='$(CC)' $(TMHS) TypeEq -otests/TypeEq.js && $(NODE) tests/TypeEq.js > tests/TypeEq.out && diff tests/TypeEq.ref tests/TypeEq.out
+	CC='$(CC)' $(TMHS) Sieve -otests/Sieve.js && $(NODE) tests/Sieve.js > tests/Sieve.out && diff tests/Sieve.ref tests/Sieve.out
+	CC='$(CC)' $(TMHS) Dict -otests/Dict.js && $(NODE) tests/Dict.js > tests/Dict.out && diff tests/Dict.ref tests/Dict.out
+	CC='$(CC)' $(TMHS) Symbol -otests/Symbol.js && $(NODE) tests/Symbol.js > tests/Symbol.out && diff tests/Symbol.ref tests/Symbol.out
+
+
+clean:
+	rm -f tests/*.out tests/*.tmp tests/*.js


### PR DESCRIPTION
### Additions
- Adds two CI entries (osx + linux) for running `mhs` tests via `node` and comparing outputs
- Adds `Makefile.emscripten` in the top-level directory (invoked using `make emscripten` from `Makefile`)
- `git` ignores some stuff

### Caveats
- Doesn't bother to compile the compiler to JS or WASM
- Doesn't contain tests for WASM (could be added later w/ `wasmer`)
- Some tests didn't pass `Foreign`, `Floating`, (so just commented them for now -- failures described below)
- Doesn't use `mhseval` for any of the tests

### Test failure summary

- `Foreign`

```
TypeError: Cannot convert -5 to a BigInt
```

- `Floating`

```
2c2
< -1.0
---
> 0.9938211910561482
```

^ still looking into these

### Improvements 

- Wasn't immediately obvious how to cleanly reuse `tests/Makefile` w/ `emcc`, but that would be an improvement to avoid some code duplication.
- Windows support code be added later