### PR TITLE
Match the output format of `mhs -ofoo.c`. 

### DIFF
--- a/Tools/Addcombs.hs
+++ b/Tools/Addcombs.hs
@@ -23,9 +23,9 @@ main = do
   file <- hGetContents ifile
   let size = length file
       chunks = chunkify 20 file
-  hPutStrLn ofile $ "const unsigned char combexprdata[] = {"
+  hPutStrLn ofile $ "static unsigned char combexprdata[] = {"
   mapM_ (hPutStrLn ofile . showChunk) chunks
-  hPutStrLn ofile "0 };"
+  hPutStrLn ofile "};"
   hPutStrLn ofile "const unsigned char *combexpr = combexprdata;"
   hPutStrLn ofile $ "const int combexprlen = " ++ show size ++ ";"
 --  hClose ifile

--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -2804,8 +2804,10 @@ main(int argc, char **argv)
       } else {
         if (strcmp(p, "-v") == 0)
           verbose++;
+#if WANT_TICKS
         else if (strcmp(p, "-T") == 0)
           dump_ticks = 1;
+#endif
         else if (strncmp(p, "-H", 2) == 0)
           heap_size = memsize(&p[2]);
         else if (strncmp(p, "-K", 2) == 0)


### PR DESCRIPTION
This avoids a segfault when compiling via `.comb` files.