### PR TITLE
Don't create indirections for unreferenced labels during deserialization

### DIFF
--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -1300,16 +1300,15 @@ parse(BFILE *f)
       l = parse_int(f);  /* The label */
       if (!gobble(f, ' ')) ERR("parse ' '");
       nodep = find_label(l);
+      x = TOP(0);
       if (*nodep == NIL) {
-        /* not referenced yet, so create a node */
-        *nodep = alloc_node(T_IND);
-        INDIR(*nodep) = NIL;
+        /* not referenced yet, so add a direct reference */
+        *nodep = x;
       } else {
         /* Sanity check */
         if (INDIR(*nodep) != NIL) ERR("shared != NIL");
+        INDIR(*nodep) = x;
       }
-      x = TOP(0);
-      INDIR(*nodep) = x;
       break;
     case '"' :
       /* Everything up to the next " is a string.


### PR DESCRIPTION
This opens the door to topologically sorting the list of bindings and squashing even more indirections.  Or, dare I say it, tree-shaking the bindings and avoiding all those A combinators.  (There are debugging reasons why that might not be a great plan, see eg https://github.com/augustss/MicroHs/pull/23)