### PR TITLE
Fix asan and ubsan violations, one of which was causing periodic crashes

### DIFF
--- a/src/runtime/config-unix-64.h
+++ b/src/runtime/config-unix-64.h
@@ -139,18 +139,19 @@ tmpname(const char* pre, const char* suf)
 {
   int pid = (int)getpid();
   char *tmp = getenv("TMPDIR");
+  const size_t PID_DIGITS = 10;
   if (!tmp)
     tmp = "/tmp";
-  char *s = malloc(strlen(tmp) + 1 + strlen(pre) + 5 + strlen(suf) + 1);
+  char *s = malloc(strlen(tmp) + 1 + strlen(pre) + PID_DIGITS + strlen(suf) + 1);
   /* This might loop forever.  See if I care. :) */
   for(;;) {
     strcpy(s, tmp);
     strcat(s, "/");
     strcat(s, pre);
-    /* Insert 8 digits of the PID */
-    char *p = s + strlen(s) + 10;
+    /* Insert PID_DIGITS digits of the PID */
+    char *p = s + strlen(s) + PID_DIGITS;
     *p-- = 0;
-    for(int i = 0; i < 10; i++) {
+    for(int i = 0; i < PID_DIGITS; i++) {
       *p-- = pid % 10 + '0';
       pid /= 10;
     }


### PR DESCRIPTION
I decided to run sanitzers on this and found why I was getting periodic heap corruption – it was tmpname overflowing its buffer.  But it's ubsan I'm interested in as I'm screwing around with eval and gc a bit and trying not to confuse the optimizer.