### PR TITLE
fix small bug in unQualString

### DIFF
--- a/src/MicroHs/Ident.hs
+++ b/src/MicroHs/Ident.hs
@@ -109,7 +109,7 @@ unqual s@(c:_) n =
       (m, '.':r) -> unqual r (n + m)
       _ -> undefined -- This cannot happen, but GHC doesn't know that
   else
-    (0, s)
+    (n, s)
   where
     -- | Like dropWhile, but also counts how many times it sees a specific character
     -- example, dropping characters until a dot, while counting how many open aprentheses are observed:


### PR DESCRIPTION
I believe I found a bug in `unQualString`. The `Ident` identifying instances, after typechecking, might have names such as `"inst$(Data.Typeable.Typeable@Control.Exception.Internal.PatternMatchFail)"`.

As an expression, `EVar -theident-`, the pretty printer will render this as an unqualified identifier. The function `unQualString` will look for `'.'` for where to split the string, but it will not take into account the parentheses. The rendered symbol will be `"PatternMatchFail)"`.

I just quickly added a fix for this, assuming that any opened parentheses will be closed at the end of the string.

I noticed this while I was poking about in the type checker, rendering the `[InstDef]` in `TModule`.