### PR TITLE
readme: update install targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Note that `mhs` built with ghc does not have all the functionality.
 Also note that there is no need to have a Haskell compiler to run MicroHs.
 All you need is a C compiler, and MicroHs can bootstrap, given the included combinator file.
 
-To install `mhs` use `make installmcabal`.  This will install `mhs` in `~/.mcabal` in the same
+To install `mhs` use `make install`.  This will install `mhs` in `~/.mcabal` in the same
 way as `mcabal` (MicroCabal) would have.  It will install a compiler binary and a compiled base package.
 You will have to add `~/.mcabal/bin` to your `PATH`.
 
-Alternatively, to install `mhs` use `make install`.  By default this copies the files to `/usr/local`,
-but this can be overridden by `make PREFIX=dir install`.
+Alternatively, to install `mhs` use `make oldinstall`.  By default this copies the files to `/usr/local`,
+but this can be overridden by `make PREFIX=dir oldinstall`.
 You also need to set the environment variable `MHSDIR`.
 
 To compile on Windows make sure `cl` is in the path, and then use `nmake` with `Makefile.windows`.


### PR DESCRIPTION
- the old make `install` target is now called `oldinstall`
- the new make `installmcabal` target is now `install`