### PR TITLE
Implement the ffsl function for OpenBSD

### DIFF
--- a/src/runtime/config-unix-64.h
+++ b/src/runtime/config-unix-64.h
@@ -49,22 +49,10 @@
  * It returns the number of the least significant bit that is set.
  * Numberings starts from 1.  If no bit is set, it should return 0.
  */
-#ifdef __OpenBSD__
-int
-ffsl(long value)
-{
-  int bit = 1;
-  if (value == 0)
-    return 0;
-  while (!(value & 1)) {
-    value >>= 1;
-    bit++;
-  }
-  return bit;
-}
-#endif
 
+#ifndef __OpenBSD__
 #define FFS ffsl
+#endif
 
 /*
  * This is the character used for comma-separation in printf.

--- a/src/runtime/config-unix-64.h
+++ b/src/runtime/config-unix-64.h
@@ -49,6 +49,21 @@
  * It returns the number of the least significant bit that is set.
  * Numberings starts from 1.  If no bit is set, it should return 0.
  */
+#ifdef __OpenBSD__
+int
+ffsl(long value)
+{
+  int bit = 1;
+  if (value == 0)
+    return 0;
+  while (!(value & 1)) {
+    value >>= 1;
+    bit++;
+  }
+  return bit;
+}
+#endif
+
 #define FFS ffsl
 
 /*


### PR DESCRIPTION
Hi Lennart,

The `ffsl()` function is a [glibc extension](https://linux.die.net/man/3/ffsl) although it may be present in other operating systems (such as [FreeBSD](https://man.freebsd.org/cgi/man.cgi?query=ffsll&sektion=3&manpath=FreeBSD+7.1-RELEASE#end) and [MacOS](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/ffsl.3.html)) so here is a minimal implementation which makes it possible to compile MicroHs on [OpenBSD 7.6](https://man.openbsd.org/ffs) (tested on the -current branch for amd64).

Edit:

Looking in to the source further I noticed that there already is [an implementation of ffsl](https://github.com/augustss/MicroHs/blob/master/src/runtime/eval.c#L116), but it isn't picked up when compiling, presumably because we define FFS as ffsl.
