### PR TITLE
Implement `clamp` in Data.Ord

### DIFF
--- a/lib/Data/Ord.hs
+++ b/lib/Data/Ord.hs
@@ -52,6 +52,9 @@ instance Bounded Ordering where
 comparing :: (Ord b) => (a -> b) -> a -> a -> Ordering
 comparing f x y = compare (f x) (f y)
 
+clamp :: (Ord a) => (a, a) -> a -> a
+clamp (low, high) a = min high (max a low)
+
 {-
 newtype Down a = Down
     { getDown :: a -- ^ @since 4.14.0.0


### PR DESCRIPTION
I stumbled across the fact that the function `clamp` is missing in `Data.Ord`. If there is a reason why the function is not implemented, please let me know and simply close the PR.