### PR TITLE
Optimize `Integer` a bit

### DIFF
--- a/lib/Data/Integer.hs
+++ b/lib/Data/Integer.hs
@@ -14,6 +14,7 @@ module Data.Integer(
 import Prelude()              -- do not import Prelude
 import Primitives
 import Control.Error
+import Data.Bits
 import Data.Bool
 import Data.Char
 import Data.Enum
@@ -148,7 +149,7 @@ add' ci []       []       = if ci == zeroD then [] else [ci]
 
 -- Add 3 digits with carry
 addD :: Digit -> Digit -> Digit -> (Digit, Digit)
-addD x y z = (quot s maxD, rem s maxD)  where s = x + y + z
+addD x y z = (quotMaxD s, remMaxD s)  where s = x + y + z
 
 -- Invariant: xs >= ys, so result is always >= 0
 sub :: [Digit] -> [Digit] -> [Digit]
@@ -164,7 +165,7 @@ sub' _  []       _        = error "impossible: xs >= ys"
 subW :: Digit -> Digit -> Digit -> (Digit, Digit)
 subW b x y =
   let d = maxD + x - y - b
-  in (1 - quot d maxD, rem d maxD)
+  in (1 - quotMaxD d, remMaxD d)
 
 -- Remove trailing 0s
 trim0 :: [Digit] -> [Digit]
@@ -196,8 +197,8 @@ mulD ci [] _ = if ci == 0 then [] else [ci]
 mulD ci (x:xs) y = r : mulD q xs y
   where
     xy = x * y + ci
-    q = quot xy maxD
-    r = rem  xy maxD
+    q = quotMaxD xy
+    r = remMaxD xy
 
 mulM :: [Digit] -> [Digit] -> [Digit]
 mulM xs ys =
@@ -240,7 +241,7 @@ quotRemD axs y = qr zeroD (reverse axs) []
     qr ci []     res = (res, [ci])
     qr ci (x:xs) res = qr r xs (q:res)
       where
-        cx = ci * maxD + x
+        cx = ci `shiftL` shiftD + x
         q = quot cx y
         r = rem cx y
 

--- a/lib/Data/Integer.hs
+++ b/lib/Data/Integer.hs
@@ -112,7 +112,8 @@ instance Eq Sign where
 -- Trim off 0s and make an Integer
 sI :: Sign -> [Digit] -> Integer
 sI s ds =
-  case trim0 ds of
+  -- Remove trailing 0s
+  case dropWhileEnd (== (0 :: Word)) ds of
     []  -> I Plus []
     ds' -> I s    ds'
 
@@ -166,10 +167,6 @@ subW :: Digit -> Digit -> Digit -> (Digit, Digit)
 subW b x y =
   let d = maxD + x - y - b
   in (1 - quotMaxD d, remMaxD d)
-
--- Remove trailing 0s
-trim0 :: [Digit] -> [Digit]
-trim0 = reverse . dropWhile (== (0 :: Word)) . reverse
 
 -- Is axs < ays?
 ltW :: [Digit] -> [Digit] -> Bool

--- a/lib/Data/Integer_Type.hs
+++ b/lib/Data/Integer_Type.hs
@@ -22,6 +22,21 @@ maxD =
   else
     error "Integer: unsupported word size"
 
+shiftD :: Int
+shiftD =
+  if _wordSize `primIntEQ` 64 then
+    (32::Int)
+  else if _wordSize `primIntEQ` 32 then
+    (16::Int)
+  else
+    error "Integer: unsupported word size"
+
+quotMaxD :: Digit -> Digit
+quotMaxD d = d `primWordShr` shiftD
+
+remMaxD :: Digit -> Digit
+remMaxD d = d `primWordAnd` (maxD `primWordSub` 1)
+
 -- Sadly, we also need a bunch of functions.
 
 _intToInteger :: Int -> Integer

--- a/lib/Data/Integer_Type.hs
+++ b/lib/Data/Integer_Type.hs
@@ -11,57 +11,61 @@ data Integer = I Sign [Digit]
 
 data Sign = Plus | Minus
 
-type Digit = Int
+type Digit = Word
 
 maxD :: Digit
 maxD =
   if _wordSize `primIntEQ` 64 then
-    (2147483648::Int)  -- 2^31, this is used so multiplication of two digits doesn't overflow a 64 bit Int
+    (4294967296 :: Word) -- 2^32, this is used so multiplication of two digits doesn't overflow a 64 bit Word
   else if _wordSize `primIntEQ` 32 then
-    (32768::Int)       -- 2^15, this is used so multiplication of two digits doesn't overflow a 32 bit Int
+    (65536 :: Word)      -- 2^16, this is used so multiplication of two digits doesn't overflow a 32 bit Word
   else
     error "Integer: unsupported word size"
 
 -- Sadly, we also need a bunch of functions.
 
 _intToInteger :: Int -> Integer
-_intToInteger i | i `primIntGE` 0  = I Plus  (f i)
-                | i `primIntEQ` ni = I Minus [0::Int,0::Int,2::Int]  -- we are at minBound::Int.
-                | True             = I Minus (f ni)
+_intToInteger i
+  | i `primIntEQ` 0 = I Plus []
+  | i `primIntGE` 0 = f Plus (primIntToWord i)
+  | True            = f Minus (primIntToWord (0 `primIntSub` i))
   where
-    ni = (0::Int) `primIntSub` i
-    f :: Int -> [Int]
-    f x = if primIntEQ x (0::Int) then [] else primIntRem x maxD : f (primIntQuot x maxD)
+    f sign i =
+      let
+        high = i `primWordQuot` maxD
+        low = i `primWordRem` maxD
+      in if high `primWordEQ` 0 then I sign [low] else I sign [low, high]
 
 _integerToInt :: Integer -> Int
-_integerToInt (I sign ds) = s `primIntMul` i
+_integerToInt x = primWordToInt (_integerToWord x)
+
+_wordToInteger :: Word -> Integer
+_wordToInteger i
+  | i    `primWordEQ` 0 = I Plus []
+  | high `primWordEQ` 0 = I Plus [low]
+  | True                = I Plus [low, high]
+  where
+    high = i `primWordQuot` maxD
+    low = i `primWordRem` maxD
+
+_integerToWord :: Integer -> Word
+_integerToWord (I sign ds) =
+  case sign of
+    Plus  -> i
+    Minus -> 0 `primWordSub` i
   where
     i =
       case ds of
-        []         -> 0::Int
-        [d1]       -> d1
-        [d1,d2]    -> d1 `primIntAdd` (maxD `primIntMul` d2)
-        d1:d2:d3:_ -> d1 `primIntAdd` (maxD `primIntMul` (d2 `primIntAdd` (maxD `primIntMul` d3)))
-    s =
-      case sign of
-        Plus  -> 1::Int
-        Minus -> 0 `primIntSub` 1
-
-_wordToInteger :: Word -> Integer
-_wordToInteger i = I Plus  (f i)
-  where
-    f :: Word -> [Int]
-    f x = if x `primWordEQ` (0::Word) then [] else primWordToInt (primWordRem x (primIntToWord maxD)) : f (primWordQuot x (primIntToWord maxD))
-
-_integerToWord :: Integer -> Word
-_integerToWord x = primIntToWord (_integerToInt x)
+        []          -> 0 :: Word
+        [d1]        -> d1
+        d1 : d2 : _ -> d1 `primWordAdd` (maxD `primWordMul` d2)
 
 _integerToFloatW :: Integer -> FloatW
 _integerToFloatW (I sign ds) = s `primFloatWMul` loop ds
   where
-    loop [] = 0.0::FloatW
-    loop (i : is) = primFloatWFromInt i `primFloatWAdd` (primFloatWFromInt maxD `primFloatWMul` loop is)
+    loop [] = 0.0 :: FloatW
+    loop (d : ds) = primFloatWFromInt (primWordToInt d) `primFloatWAdd` (primFloatWFromInt (primWordToInt maxD) `primFloatWMul` loop ds)
     s =
       case sign of
-        Plus  -> 1.0::FloatW
+        Plus  -> 1.0 :: FloatW
         Minus -> 0.0 `primFloatWSub` 1.0

--- a/lib/Data/Word.hs
+++ b/lib/Data/Word.hs
@@ -12,12 +12,13 @@ import Data.Enum
 import Data.Eq
 import Data.Function
 import Data.Int()  -- instances only
-import Data.Integer
+import Data.Integer_Type
 import Data.Integral
 import Data.List
 import Data.Maybe_Type
 import Data.Num
 import Data.Ord
+import Data.Ratio_Type
 import Data.Real
 import Numeric.Show
 import Text.Show
@@ -28,7 +29,7 @@ instance Num Word where
   (*)  = primWordMul
   abs x = x
   signum x = if x == 0 then 0 else 1
-  fromInteger x = primIntToWord (_integerToInt x)
+  fromInteger = _integerToWord
 
 instance Integral Word where
   quot = primWordQuot


### PR DESCRIPTION
Some small optimizations for `Integer`s. Each optimization is in its own commit:
* Since each digit is nonnegative, we can use `Word` instead of `Int` to represent digits. This allows us to use half of the bits (16/32) without multiplication overflow. It also has the effect that any `Int` and `Word` can be represented using at most 2 digits.
* Since `maxD` is a power of 2, we can use bit operations instead of `quot` and `rem` (see `quotMaxD`, `remMaxD`).
* `dropWhileEnd (== 0)` seems to be a bit more efficient than `reverse . dropWhile (== 0) . reverse`.
* `quotRemI` used to traverse `ys` 4 times in the case that all digits except the MSD are 0: once for `init`, `last`, `length` and `all`. `msd` does all this in a single traversal.
* ~~`_integerToIntList` and `_intListToInteger` used costly `Integer` division and multiplication. By changing the base to 2^16=32768, we can either reuse the list (on 32 bit platforms) or split/merge 2 elements (on 64 bit platforms), avoiding any expensive operations.~~

I tried to rewrite `Integer` to use arrays (using my own array type based on `IOArray`), however that implementation was quite a bit slower than the current list-based implementation. Implementing `Integer` in the runtime should make it significantly faster, be it by using an existing library (e.g. GMP, like GHC does by default) or by manually writing a C implementation (I'd be generally willing to try this), but I'm not sure if this is even desirable, since MicroHs is supposed to be minimal.