### PR TITLE
Integer: Optimize comparisons

### DIFF
--- a/lib/Data/Integer.hs
+++ b/lib/Data/Integer.hs
@@ -30,6 +30,7 @@ instance Eq Integer where
   (/=) = neI
 
 instance Ord Integer where
+  compare = cmpI
   (<)  = ltI
   (<=) = leI
   (>)  = gtI


### PR DESCRIPTION
Compare `Integer`s using a single traversal of the digits, rather than computing the lengths and reversing the lists first.