### PR TITLE
Export `evaluate` and `mapException` from `Control.Exception`

### DIFF
--- a/lib/Control/Exception.hs
+++ b/lib/Control/Exception.hs
@@ -12,11 +12,13 @@ module Control.Exception(
   handle, handleJust,
 
   bracket, finally, bracket_, bracketOnError,
-  
+
   try,
   throwIO,
   onException,
   displaySomeException,
+  evaluate,
+  mapException,
   --
   ArithException(..),
   ) where


### PR DESCRIPTION
I don't see any reason why they're not exported.