### PR TITLE
Fix GMP `popCount` & `shiftR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,8 +451,8 @@ and also the [hugs branch of MicroHs](https://github.com/augustss/MicroHs/tree/h
 
 ## Using GMP for `Integer`
 The default implementation of the `Integer` type is written is Haskell and is quite slow.
-It is possible to use GMP [GNU Multi Precision](https://gmplib.org/) instead.
-To use GMP you need to uncomment the first few line in the `Makefile`, and also
+It is possible to use the [GMP](https://gmplib.org/) library instead.
+To use GMP you need to uncomment the first few lines in the `Makefile`, and also
 modify the definition that directs the C compiler where to find GMP.
 
 ***NOTE*** To switch between using and not using GMP you need to do `make clean`.

--- a/lib/gmp/Data/Integer/Internal.hs
+++ b/lib/gmp/Data/Integer/Internal.hs
@@ -28,7 +28,7 @@ import Data.Integer_Type
 
 -- We cannot import Foreign.ForeignPtr; it is circular.
 withForeignPtr :: ForeignPtr a -> (Ptr a -> IO b) -> IO b
-withForeignPtr fp io = 
+withForeignPtr fp io =
   io (primForeignPtrToPtr fp) `primBind` \ b ->
   primSeq fp (primReturn b)
 
@@ -45,7 +45,7 @@ foreign import capi "mpz_and"         mpz_and         :: Ptr MPZ -> Ptr MPZ -> P
 foreign import capi "mpz_ior"         mpz_ior         :: Ptr MPZ -> Ptr MPZ -> Ptr MPZ ->            IO ()
 foreign import capi "mpz_xor"         mpz_xor         :: Ptr MPZ -> Ptr MPZ -> Ptr MPZ ->            IO ()
 foreign import capi "mpz_mul_2exp"    mpz_mul_2exp    :: Ptr MPZ -> Ptr MPZ -> Int ->                IO ()
-foreign import capi "mpz_tdiv_q_2exp" mpz_tdiv_q_2exp :: Ptr MPZ -> Ptr MPZ -> Int ->                IO ()
+foreign import capi "mpz_fdiv_q_2exp" mpz_fdiv_q_2exp :: Ptr MPZ -> Ptr MPZ -> Int ->                IO ()
 foreign import capi "mpz_popcount"    mpz_popcount    :: Ptr MPZ ->                                  IO Int
 foreign import capi "mpz_tstbit"      mpz_tstbit      :: Ptr MPZ -> Int ->                           IO Int
 
@@ -107,7 +107,7 @@ isZero :: Integer -> Bool
 isZero = eqI zeroI
 
 cmpop :: (Int -> a) -> Integer -> Integer -> a
-cmpop f (I x) (I y) = unsafePerformIO $ 
+cmpop f (I x) (I y) = unsafePerformIO $
   withForeignPtr x $ \ px ->
     withForeignPtr y $ \ py -> do
       s <- mpz_cmp px py
@@ -155,7 +155,7 @@ shiftLI :: Integer -> Int -> Integer
 shiftLI x i = unop (\ pz px -> mpz_mul_2exp pz px i) x
 
 shiftRI :: Integer -> Int -> Integer
-shiftRI x i = unop (\ pz px -> mpz_tdiv_q_2exp pz px i) x
+shiftRI x i = unop (\ pz px -> mpz_fdiv_q_2exp pz px i) x
 
 popCountI :: Integer -> Int
 popCountI (I x) = unsafePerformIO $ withForeignPtr x $ mpz_popcount

--- a/src/MicroHs/FFI.hs
+++ b/src/MicroHs/FFI.hs
@@ -174,7 +174,7 @@ runtimeFFI :: [String]
 runtimeFFI = [
   "GETRAW", "GETTIMEMILLI", "acos", "add_FILE", "add_utf8", "asin", "atan", "atan2", "calloc", "closeb",
   "cos", "exp", "flushb", "fopen", "free", "getb", "getenv", "iswindows", "log", "malloc",
-  "md5Array", "md5BFILE", "md5String", "memcpy", "memmove", 
+  "md5Array", "md5BFILE", "md5String", "memcpy", "memmove",
   "putb", "sin", "sqrt", "system", "tan", "tmpname", "ungetb", "unlink",
   "peekPtr", "pokePtr", "pokeWord", "peekWord",
   "add_lz77_compressor", "add_lz77_decompressor",
@@ -190,9 +190,9 @@ runtimeFFI = [
   "sizeof_int", "sizeof_long", "sizeof_llong",
   "opendir", "closedir", "readdir", "c_d_name", "chdir", "mkdir", "getcwd",
   "get_buf", "openb_rd_buf", "openb_wr_buf",
-  "new_mpz", "mpz_abs", "mpz_add", "mpz_and", "mpz_cmp", "mpz_get_d", 
-  "mpz_get_si", "mpz_get_ui", "mpz_init_set_si", "mpz_init_set_ui", "mpz_ior", 
-  "mpz_mul", "mpz_mul_2exp", "mpz_neg", "mpz_popcount", "mpz_sub", "mpz_tdiv_q_2exp", 
+  "new_mpz", "mpz_abs", "mpz_add", "mpz_and", "mpz_cmp", "mpz_get_d",
+  "mpz_get_si", "mpz_get_ui", "mpz_init_set_si", "mpz_init_set_ui", "mpz_ior",
+  "mpz_mul", "mpz_mul_2exp", "mpz_neg", "mpz_popcount", "mpz_sub", "mpz_fdiv_q_2exp",
   "mpz_tdiv_qr", "mpz_tstbit", "mpz_xor",
   "want_gmp"
   ]

--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -4634,9 +4634,20 @@ void mhs_mpz_ior(int s) { mpz_ior(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Ptr
 void mhs_mpz_mul(int s) { mpz_mul(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Ptr(s, 2)); mhs_from_Unit(s, 3); }
 void mhs_mpz_mul_2exp(int s) { mpz_mul_2exp(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Int(s, 2)); mhs_from_Unit(s, 3); }
 void mhs_mpz_neg(int s) { mpz_neg(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1)); mhs_from_Unit(s, 2); }
-void mhs_mpz_popcount(int s) { mhs_from_Int(s, 1, mpz_popcount(mhs_to_Ptr(s, 0))); }
+void mhs_mpz_popcount(int s) {
+  mpz_ptr a = mhs_to_Ptr(s, 0);
+  if (mpz_sgn(a) < 0) {
+    mpz_t neg_a;
+    mpz_init(neg_a);
+    mpz_neg(neg_a, a);
+    mhs_from_Int(s, 1, -mpz_popcount(neg_a));
+    mpz_clear(neg_a);
+  } else {
+    mhs_from_Int(s, 1, mpz_popcount(a));
+  }
+}
 void mhs_mpz_sub(int s) { mpz_sub(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Ptr(s, 2)); mhs_from_Unit(s, 3); }
-void mhs_mpz_tdiv_q_2exp(int s) { mpz_tdiv_q_2exp(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Int(s, 2)); mhs_from_Unit(s, 3); }
+void mhs_mpz_fdiv_q_2exp(int s) { mpz_fdiv_q_2exp(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Int(s, 2)); mhs_from_Unit(s, 3); }
 void mhs_mpz_tdiv_qr(int s) { mpz_tdiv_qr(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Ptr(s, 2), mhs_to_Ptr(s, 3)); mhs_from_Unit(s, 4); }
 void mhs_mpz_tstbit(int s) { mhs_from_Int(s, 2, mpz_tstbit(mhs_to_Ptr(s, 0), mhs_to_Int(s, 1))); }
 void mhs_mpz_xor(int s) { mpz_xor(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Ptr(s, 2)); mhs_from_Unit(s, 3); }
@@ -4782,7 +4793,7 @@ struct ffi_entry ffi_table[] = {
 { "mpz_neg", mhs_mpz_neg},
 { "mpz_popcount", mhs_mpz_popcount},
 { "mpz_sub", mhs_mpz_sub},
-{ "mpz_tdiv_q_2exp", mhs_mpz_tdiv_q_2exp},
+{ "mpz_fdiv_q_2exp", mhs_mpz_fdiv_q_2exp},
 { "mpz_tdiv_qr", mhs_mpz_tdiv_qr},
 { "mpz_tstbit", mhs_mpz_tstbit},
 { "mpz_xor", mhs_mpz_xor},


### PR DESCRIPTION
* For `shiftR`, we want `mpz_fdiv_q_2exp` (rounding down towards -infinity) instead of `mpz_tdiv_q_2exp` (rounding towards zero). E.g. ``(-1 :: Integer) `shiftR` 1 == -1``.
* For `popCount` on negative integers, we want -1 times the popcount of the absolute value, so I added code to negate the input and output in case the input is negative.