### PR TITLE
Better `IsString` instance for `String`

### DIFF
--- a/lib/Data/String.hs
+++ b/lib/Data/String.hs
@@ -14,5 +14,5 @@ import Data.List
 class IsString a where
   fromString :: String -> a
 
-instance IsString String where
+instance (a ~ Char) => IsString [a] where
   fromString s = s

--- a/tests/StringTest.hs
+++ b/tests/StringTest.hs
@@ -6,18 +6,20 @@ main :: IO ()
 main = do
   putStrLn $ if "abc" == "abc" then "yes" else "no"
   putStrLn $ if "abc" == "adc" then "yes" else "no"
-  putStrLn $ show (1234::Int)
-  putStrLn $ show (0::Int)
-  putStrLn $ show (- (567::Int))
-  putStrLn $ show 'x'
-  putStrLn $ show '\n'
-  putStrLn $ show False
+  print (1234::Int)
+  print (0::Int)
+  print (- (567::Int))
+  print 'x'
+  print '\n'
+  print False
 --  putStrLn $ showUnit ()
-  putStrLn $ show [1,20,3::Int]
-  putStrLn $ show [1::Int]
-  putStrLn $ show ([] :: [Int])
-  putStrLn $ show (123::Int, 'a')
-  putStrLn $ show (Nothing :: Maybe Int)
-  putStrLn $ show (Just 890 :: Maybe Int)
-  putStrLn $ show (Left   678 :: Either Int Bool)
-  putStrLn $ show (Right True :: Either Int Bool)
+  print [1,20,3::Int]
+  print [1::Int]
+  print ([] :: [Int])
+  print (123::Int, 'a')
+  print (Nothing :: Maybe Int)
+  print (Just 890 :: Maybe Int)
+  print (Left   678 :: Either Int Bool)
+  print (Right True :: Either Int Bool)
+  print $ length "hello"
+

--- a/tests/StringTest.ref
+++ b/tests/StringTest.ref
@@ -14,3 +14,4 @@ Nothing
 Just 890
 Left 678
 Right True
+5


### PR DESCRIPTION
Change to `instance (a ~ Char) => IsString [a]`, so that the string type can be inferred if it is known to be a list (e.g. in `length "hello"`). This is also in `base`, see https://hackage.haskell.org/package/ghc-internal-9.1201.0/docs/src/GHC.Internal.Data.String.html#line-63.