### PR TITLE
Switch to git submodule for cpphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ targets.conf
 timing
 mdist/*
 dist-mcabal/
-cpphssrc/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cpphssrc/malcolm-wallace-universe"]
+	path = cpphssrc/malcolm-wallace-universe
+	url = https://github.com/hackage-trustees/malcolm-wallace-universe.git

--- a/Makefile
+++ b/Makefile
@@ -136,14 +136,14 @@ bin/mhs-stage2:	bin/mhs-stage1 src/*/*.hs
 	@echo "*** stage2 equal to stage1"
 	$(CCEVAL) generated/mhs-stage2.c -o bin/mhs-stage2
 
-cpphssrc/malcolm-wallace-universe:
-	mkdir -p cpphssrc
-	cd cpphssrc; git clone git@github.com:hackage-trustees/malcolm-wallace-universe.git
+# Fetch cpphs submodule
+cpphssrc/malcolm-wallace-universe/.git:
+	git submodule update --init --depth 1 cpphssrc/malcolm-wallace-universe
 
 # Use this cpphs for bootstrapping
 USECPPHS=bin/cpphs
 
-bootstrapcpphs: bin/mhs cpphssrc/malcolm-wallace-universe
+bootstrapcpphs: bin/mhs cpphssrc/malcolm-wallace-universe/.git
 	MHSCPPHS=$(USECPPHS) bin/mhs -z -XCPP '-DMIN_VERSION_base(x,y,z)=((x)<4||(x)==4&&(y)<19||(x)==4&&(y)==19&&(z)<=1)' -icpphscompat -icpphssrc/malcolm-wallace-universe/polyparse-1.12/src -icpphssrc/malcolm-wallace-universe/cpphs-1.20.9 cpphssrc/malcolm-wallace-universe/cpphs-1.20.9/cpphs.hs -ogenerated/cpphs.c
 
 # Run test examples with ghc-compiled compiler


### PR DESCRIPTION
Use git submodule instead of git clone for fetching cpphs. This is better for reproducability as cpphs may change in a MicroHs incompatible way in the future.