### PR TITLE
Uncomment `PrintfArg Double` instance

### DIFF
--- a/lib/Text/Printf.hs
+++ b/lib/Text/Printf.hs
@@ -395,11 +395,9 @@ instance PrintfArg Natural where
 instance PrintfArg Float where
     formatArg = formatRealFloat
 
-{- Double=Float
 -- | @since 2.01
 instance PrintfArg Double where
     formatArg = formatRealFloat
--}
 
 -- | This class, with only the one instance, is used as
 -- a workaround for the fact that 'String', as a concrete


### PR DESCRIPTION
Make it possible to use `Double` with  `printf`. Is there any reason why it was commented out?