### PR TITLE
Integer: simplify `shiftD` computation

### DIFF
--- a/lib/Data/Integer_Type.hs
+++ b/lib/Data/Integer_Type.hs
@@ -25,13 +25,7 @@ maxD :: Digit
 maxD = 1 `primWordShl` shiftD
 
 shiftD :: Int
-shiftD =
-  if _wordSize `primIntEQ` 64 then
-    (32 :: Int) -- this is used so multiplication of two digits doesn't overflow a 64 bit Word
-  else if _wordSize `primIntEQ` 32 then
-    (16 :: Int) -- this is used so multiplication of two digits doesn't overflow a 32 bit Word
-  else
-    error "Integer: unsupported word size"
+shiftD = _wordSize `primIntShr` 1 -- this is used so multiplication of two digits doesn't overflow a Word
 
 quotMaxD :: Digit -> Digit
 quotMaxD d = d `primWordShr` shiftD


### PR DESCRIPTION
We always want half the word size as `shiftD`. With this change, `Integer` should also work on e.g. 16 bit platforms.