### PR TITLE
Small optimization in `MicroHs.Builtin`

### DIFF
--- a/src/MicroHs/Builtin.hs
+++ b/src/MicroHs/Builtin.hs
@@ -1,5 +1,6 @@
 module MicroHs.Builtin(
   builtinMdl,
+  builtinMdlQ,
   mkBuiltin,
   mkBuiltinQ,
   ) where
@@ -11,15 +12,15 @@ import MicroHs.Ident
 --  'import Mhs.Builtin qualified as B@"
 -- The name 'B@' is not a valid identifier, so these name
 -- cannot be used accidentally in user code.
-builtinMdl :: String
-builtinMdl = "B@"
-builtinMdlQ :: String
-builtinMdlQ = "Mhs.Builtin"
+builtinMdl :: Ident
+builtinMdl = mkIdent "B@"
+builtinMdlQ :: Ident
+builtinMdlQ = mkIdent "Mhs.Builtin"
 
 -- Identifier for a builtin that will be renamed.
 mkBuiltin :: SLoc -> String -> Ident
-mkBuiltin loc name = mkIdentSLoc loc ((builtinMdl ++ ".") ++ name)
+mkBuiltin loc name = qualIdent builtinMdl (mkIdentSLoc loc name)
 
 -- Identifier for a builtin that is alread renamed.
 mkBuiltinQ :: SLoc -> String -> Ident
-mkBuiltinQ loc name = mkIdentSLoc loc ((builtinMdlQ ++ ".") ++ name)
+mkBuiltinQ loc name = qualIdent builtinMdlQ (mkIdentSLoc loc name)

--- a/src/MicroHs/Compile.hs
+++ b/src/MicroHs/Compile.hs
@@ -237,9 +237,7 @@ addPreludeImport (EModule mn es ds) =
         isImportPrelude (Import (ImportSpec _ _ i _ _)) = i == idPrelude
         isImportPrelude _ = False
         idPrelude = mkIdent "Prelude"
-        idBuiltin = mkIdent "Mhs.Builtin"
-        idB = mkIdent builtinMdl
-        iblt = Import $ ImportSpec ImpNormal True idBuiltin (Just idB) Nothing
+        iblt = Import $ ImportSpec ImpNormal True builtinMdlQ (Just builtinMdl) Nothing
         ps' =
           case ps of
             [] -> [Import $ ImportSpec ImpNormal False idPrelude Nothing Nothing,      -- no Prelude imports, so add 'import Prelude'

--- a/src/MicroHs/SymTab.hs
+++ b/src/MicroHs/SymTab.hs
@@ -102,7 +102,7 @@ stLookup msg i (SymTab l ug qg) =
 -- unqualified.
 hackBuiltin :: Ident -> Ident
 hackBuiltin i =
-  case stripPrefix builtinMdl (unIdent i) of
+  case stripPrefix (unIdent builtinMdl) (unIdent i) of
     Just ('.':s) -> mkIdentSLoc (slocIdent i) s
     _            -> i
 


### PR DESCRIPTION
Only `pack` `"B@"`/`"Mhs.Builtin"` once. This slightly improves performance (~0.01%).