### PR TITLE
Add isSigned to class Bits

### DIFF
--- a/lib/Data/Bits.hs
+++ b/lib/Data/Bits.hs
@@ -36,6 +36,7 @@ class Eq a => Bits a where
   popCount          :: a -> Int
   bitSizeMaybe      :: a -> Maybe Int
   bitSize           :: a -> Int
+  isSigned          :: a -> Bool
 
   x `shift`   i | i<0       = x `shiftR` (- i)
                 | i>0       = x `shiftL` i
@@ -129,6 +130,7 @@ instance Bits Int where
   testBit = testBitDefault
   popCount = primIntPopcount
   zeroBits = 0
+  isSigned _ = True
 
 instance FiniteBits Int where
   finiteBitSize _ = _wordSize

--- a/lib/Data/Int/Instances.hs
+++ b/lib/Data/Int/Instances.hs
@@ -113,6 +113,7 @@ instance Bits Int8 where
   testBit = testBitDefault
   popCount (I8 x) = primIntPopcount (x .&. 0xff)
   zeroBits = 0
+  isSigned _ = True
 
 instance FiniteBits Int8 where
   finiteBitSize _ = 8
@@ -211,6 +212,7 @@ instance Bits Int16 where
   testBit = testBitDefault
   popCount (I16 x) = primIntPopcount (x .&. 0xffff)
   zeroBits = 0
+  isSigned _ = True
 
 instance FiniteBits Int16 where
   finiteBitSize _ = 16
@@ -309,6 +311,7 @@ instance Bits Int32 where
   testBit = testBitDefault
   popCount (I32 x) = primIntPopcount (x .&. 0xffffffff)
   zeroBits = 0
+  isSigned _ = True
 
 instance FiniteBits Int32 where
   finiteBitSize _ = 32
@@ -406,6 +409,7 @@ instance Bits Int64 where
   testBit = testBitDefault
   popCount (I64 x) = primIntPopcount x
   zeroBits = 0
+  isSigned _ = True
 
 instance FiniteBits Int64 where
   finiteBitSize _ = 64

--- a/lib/Data/Integer.hs
+++ b/lib/Data/Integer.hs
@@ -96,6 +96,7 @@ instance Bits Integer where
   zeroBits = zeroI
   bitSizeMaybe _ = Nothing
   popCount = popCountI
+  isSigned _ = True
 
 -----------------
 

--- a/lib/Data/Word.hs
+++ b/lib/Data/Word.hs
@@ -133,6 +133,7 @@ instance Bits Word where
   testBit = testBitDefault
   popCount = primWordPopcount
   zeroBits = 0
+  isSigned _ = False
 
 instance FiniteBits Word where
   finiteBitSize _ = _wordSize
@@ -233,6 +234,7 @@ instance Bits Word8 where
   testBit = testBitDefault
   popCount = primWordPopcount . unW8
   zeroBits = 0
+  isSigned _ = False
 
 instance FiniteBits Word8 where
   finiteBitSize _ = 8
@@ -333,6 +335,7 @@ instance Bits Word16 where
   testBit = testBitDefault
   popCount = primWordPopcount . unW16
   zeroBits = 0
+  isSigned _ = False
 
 instance FiniteBits Word16 where
   finiteBitSize _ = 16
@@ -433,6 +436,7 @@ instance Bits Word32 where
   testBit = testBitDefault
   popCount = primWordPopcount . unW32
   zeroBits = 0
+  isSigned _ = False
 
 instance FiniteBits Word32 where
   finiteBitSize _ = 32
@@ -533,6 +537,7 @@ instance Bits Word64 where
   testBit = testBitDefault
   popCount = primWordPopcount . unW64
   zeroBits = 0
+  isSigned _ = False
 
 instance FiniteBits Word64 where
   finiteBitSize _ = 64

--- a/lib/Numeric/Natural.hs
+++ b/lib/Numeric/Natural.hs
@@ -70,3 +70,4 @@ instance Bits Natural where
   popCount = coerce (popCount @Integer)
   bitSizeMaybe = coerce (bitSizeMaybe @Integer)
   bitSize = coerce (bitSize @Integer)
+  isSigned _ = False


### PR DESCRIPTION
Bits.isSigned is defined in Haskell 2010 and is present in GHC base.

(From https://github.com/augustss/MicroHs/pull/166#issuecomment-2708965073)