### PR TITLE
Make emscripten CI less fragile

### DIFF
--- a/.github/workflows/mhs-ci.yml
+++ b/.github/workflows/mhs-ci.yml
@@ -220,6 +220,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
+    - uses: haskell-actions/setup@v2
     - name: make newmhs
       run: make newmhs
     - name: run emscripten tests
@@ -233,6 +234,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
+    - uses: haskell-actions/setup@v2
     - name: make newmhs
       run: make newmhs
     - name: run emscripten tests

--- a/.github/workflows/mhs-ci.yml
+++ b/.github/workflows/mhs-ci.yml
@@ -215,21 +215,25 @@ jobs:
   build-linux-emscripten:
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v4
-     - uses: mymindstorm/setup-emsdk@v13
-     - uses: actions/setup-node@v4
-       with:
-         node-version: 20
-     - name: run emscripten tests
-       run: make runtestemscripten
+    - uses: actions/checkout@v4
+    - uses: mymindstorm/setup-emsdk@v13
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - name: make newmhs
+      run: make newmhs
+    - name: run emscripten tests
+      run: make runtestemscripten
 
   build-macos-emscripten:
     runs-on: macos-latest
     steps:
-     - uses: actions/checkout@v4
-     - uses: mymindstorm/setup-emsdk@v13
-     - uses: actions/setup-node@v4
-       with:
-         node-version: 20
-     - name: run emscripten tests
-       run: make runtestemscripten
+    - uses: actions/checkout@v4
+    - uses: mymindstorm/setup-emsdk@v13
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - name: make newmhs
+      run: make newmhs
+    - name: run emscripten tests
+      run: make runtestemscripten


### PR DESCRIPTION
Run `make newmhs` before running the emscripten tests, to avoids failures like https://github.com/augustss/MicroHs/pull/155#issuecomment-2701373378.