### PR TITLE
Ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ targets.conf
 timing
 mdist/*
 dist-mcabal/
+generated/


### PR DESCRIPTION
I ran `make bootstrap` and presume the generated files should be ignored:

```
$ make bootstrap
*** Build stage1 compiler, using bin/mhs
bin/mhs -z -i  -imhs -isrc -ilib -ipaths  MicroHs.Main -ogenerated/mhs-stage1.c
cc -Wall -O3  -Isrc/runtime src/runtime/eval-unix-64.c -lm generated/mhs-stage1.c -o bin/mhs-stage1
*** Build stage2 compiler, with stage1 compiler
bin/mhs-stage1 -z -i  -imhs -isrc -ilib -ipaths  MicroHs.Main -ogenerated/mhs-stage2.c
cmp generated/mhs-stage1.c generated/mhs-stage2.c
*** stage2 equal to stage1
cc -Wall -O3  -Isrc/runtime src/runtime/eval-unix-64.c -lm generated/mhs-stage2.c -o bin/mhs-stage2
*** copy stage2 to bin/mhs
cp bin/mhs-stage2 bin/mhs
cp generated/mhs-stage2.c generated/mhs.c
```

```
$ git status
On branch ignore/generated
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	generated/mhs-stage1.c
	generated/mhs-stage2.c

nothing added to commit but untracked files present (use "git add" to track)
```
