### PR TITLE
Speed up node allocation noticeably by avoiding FFS(...)

### DIFF
--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -676,15 +676,15 @@ alloc_node(enum node_tag t)
   int k;                        /* will contain bit pos + 1 */
   heapoffs_t pos;
   NODEPTR n;
+  heapoffs_t word;
 
   /* This can happen if we run out of memory when parsing. */
   if (num_free <= 0)
     ERR("alloc_node");
 
   for(;;) {
-    heapoffs_t word = free_map[i];
-    k = FFS(word);
-    if (k)
+    word = free_map[i];
+    if (word)
       break;
     i++;
 #if SANITY
@@ -697,9 +697,11 @@ alloc_node(enum node_tag t)
     }
 #endif
   }
+  k = FFS(word);
   pos = i * BITS_PER_WORD + k - 1; /* first free node */
   n = HEAPREF(pos);
-  mark_used(n);
+  // mark_used(n); // equivalent to:
+  free_map[i] = word & (word-1);
   next_scan_index = pos;
 
   SETTAG(n, t);


### PR DESCRIPTION
when skipping full regions, and using standard bit fiddling to mark as used.  This offers a nice (and repeatable) speedup on my MacBook Pro.  It should be a LOT better on any arch that lacks native FFS support.

(Note: I've deleted the GC stats because they're the same between runs)

Baseline (master):
2ad52978fc17d361f43a9e47f708935d0853df41
time bin/mhs +RTS -v -RTS -s -i  -imhs -isrc -ilib -ipaths  MicroHs.Main 1940 lines/s
       24.40 real        23.59 user         0.22 sys
time bin/mhs +RTS -v -RTS -CW AllOfLib
       20.47 real        19.73 user         0.16 sys
time bin/mhs +RTS -v -RTS -CR -s -i  -imhs -isrc -ilib -ipaths  MicroHs.Main
4339 lines/s
       16.34 real        15.94 user         0.18 sys

With FFS avoidance and faster mark_used in alloc_node: 2ad52978fc17d361f43a9e47f708935d0853df41
time bin/mhs +RTS -v -RTS -s -i  -imhs -isrc -ilib -ipaths  MicroHs.Main 2084 lines/s
       22.76 real        21.90 user         0.25 sys
time bin/mhs +RTS -v -RTS -CW AllOfLib
       18.69 real        17.87 user         0.23 sys
time bin/mhs +RTS -v -RTS -CR -s -i  -imhs -isrc -ilib -ipaths  MicroHs.Main
4667 lines/s
       15.21 real        14.71 user         0.19 sys