### PR TITLE
Fix compiler error with Unicode ByteString literals

### DIFF
--- a/src/MicroHs/ExpPrint.hs
+++ b/src/MicroHs/ExpPrint.hs
@@ -112,7 +112,7 @@ quoteString s =
       | c < '\xa0'             = ['^', chr (ord c - 0x80 + 0x40)]
       | c < '\xff'             = ['|', chr (ord c - 0x80)]
       | otherwise              = "\\_"
-  in  '"' : concatMap achar s ++ ['"']
+  in  '"' : concatMap (\c -> achar (chr (ord c `rem` 256))) s ++ ['"']
 
 encodeString :: String -> Exp
 encodeString = encList . map (Lit . LInt . ord)

--- a/tests/Bytestring.hs
+++ b/tests/Bytestring.hs
@@ -40,3 +40,6 @@ main = do
   print $ isValidUtf8 "\xF4\x90\x80\x80"
   print $ isValidUtf8 "\xED\xA0\x80" -- low surrogate
   print $ isValidUtf8 "\xED\xBF\xBF" -- high surrogate
+
+  -- ByteString literals
+  print ("øßΞóïűæいהłДป็ş" :: ByteString)

--- a/tests/Bytestring.ref
+++ b/tests/Bytestring.ref
@@ -15,3 +15,4 @@ False
 False
 False
 False
+"\248\223\158\243\239q\230D\212B\DC4\ESCG_"


### PR DESCRIPTION
The `IsString ByteString` instance truncates the `Char`s to `Word8`s. `ByteString` literals assumed that the `Char`s were already truncated, leading to a compiler crash when using Unicode `ByteString` literals.