### PR TITLE
Make `Foreign.Marshal` & `Foreign.Marshal.Error` report compliant

### DIFF
--- a/lib/Foreign/Marshal.hs
+++ b/lib/Foreign/Marshal.hs
@@ -2,12 +2,16 @@ module Foreign.Marshal(
   module Foreign.Marshal.Alloc,
   module Foreign.Marshal.Array,
   module Foreign.Marshal.Error,
---  module Foreign.Marshal.Pool,
-  module Foreign.Marshal.Utils
+  module Foreign.Marshal.Utils,
+  unsafeLocalState,
   ) where
+
+import Primitives (primPerformIO)
 
 import Foreign.Marshal.Alloc
 import Foreign.Marshal.Array
 import Foreign.Marshal.Error
---import Foreign.Marshal.Pool
 import Foreign.Marshal.Utils
+
+unsafeLocalState :: IO a -> a
+unsafeLocalState = primPerformIO

--- a/lib/Foreign/Marshal/Error.hs
+++ b/lib/Foreign/Marshal/Error.hs
@@ -4,6 +4,7 @@ module Foreign.Marshal.Error (
   throwIfNeg,
   throwIfNeg_,
   throwIfNull,
+  void,
 ) where
 import qualified Prelude(); import MiniPrelude
 import Data.Functor(void)


### PR DESCRIPTION
The report specifies `Foreign.Marshal.Error.void` to have type `IO a -> IO ()`, whereas this PR reexports `Data.Functor.void` (which has type `Functor f => f a -> f ()`). I can change it to strictly adhere to the report, but ig this is good enough. For the record, `base` has a separate `void :: IO a -> IO ()`, but it's deprecated (in favor of `Data.Functor.void`).