### PR TITLE
Fix combinator naming

### DIFF
--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -937,7 +937,7 @@ init_nodes(void)
     default:
       break;
     }
-    for (j = 0; j < sizeof primops / sizeof primops[0];j++) {
+    for (j = sizeof primops / sizeof primops[0]; j-- > 0; ) {
       if (primops[j].tag == t) {
         primops[j].node = n;
       }


### PR DESCRIPTION
Combinator names on master are assigned based on the *last* thing we see that matches the combinator.  This leads to unintuitive stuff like:

> cprint id
chr

By reversing the order of name assignment, we favor combinator names over primitives that happen to be spelled the same way.