### PR TITLE
sprintf -> snprintf

### DIFF
--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -2232,7 +2232,7 @@ printrec(BFILE *f, struct print_bits *pb, NODEPTR n, int prefix)
     break;
   case T_PTR:
     if (prefix) {
-      char b[200]; sprintf(b,"PTR<%p>",PTR(n));
+      char b[200]; snprintf(b,200,"PTR<%p>",PTR(n));
       putsb(b, f);
     } else {
       ERR("Cannot serialize pointers");


### PR DESCRIPTION
sprintf makes sanitized builds justifiably unhappy.  This is a trivial fix, especially as eval.c already calls snprintf in convdbl.