### PR TITLE
`hClose` on closed handle should do nothing

### DIFF
--- a/lib/System/IO.hs
+++ b/lib/System/IO.hs
@@ -104,7 +104,7 @@ hCloseReal :: Handle -> IO ()
 hCloseReal h = do
   m <- getHandleState h
   case m of
-    HClosed -> ioErrH h OtherError "hClose: Handle already closed"
+    HClosed -> return ()
     HSemiClosed -> return ()
     _ -> do
       killHandle h


### PR DESCRIPTION
From the report:
> Performing `hClose` on a handle that has already been closed has no effect; doing so is not an error.