### PR TITLE
Add instances to make acme-smuggler compile

### DIFF
--- a/lib/Data/Dynamic.hs
+++ b/lib/Data/Dynamic.hs
@@ -11,8 +11,15 @@ import Data.Maybe
 import Data.Proxy
 import Data.Typeable
 import Unsafe.Coerce
+import Control.Exception
 
 data Dynamic = D TypeRep AnyType
+  deriving Typeable
+
+instance Exception Dynamic
+
+instance Show Dynamic where
+  show (D t _) = "<<" ++ show t ++ ">>"
 
 toDyn :: forall a . Typeable a => a -> Dynamic
 toDyn a = D (typeOf a) (unsafeCoerce a)


### PR DESCRIPTION
This package is on hackage but not the stack repository that mcabal builds from. Instead I tested against a checkout of
https://github.com/benclifford/acme-smuggler

The new Show instance produces the same format output as GHC.