### PR TITLE
Simplify emscripten CI

### DIFF
--- a/.github/workflows/mhs-ci.yml
+++ b/.github/workflows/mhs-ci.yml
@@ -212,22 +212,11 @@ jobs:
 #      run: make CONF=unix everytestmhs
 #      shell: alpine.sh {0}
 
-  build-linux-emscripten:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mymindstorm/setup-emsdk@v13
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20
-    - uses: haskell-actions/setup@v2
-    - name: make newmhs
-      run: make newmhs
-    - name: run emscripten tests
-      run: make runtestemscripten
-
-  build-macos-emscripten:
-    runs-on: macos-latest
+  build-emscripten:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: mymindstorm/setup-emsdk@v13


### PR DESCRIPTION
Combine `build-linux-emscripten` and `build-macos-emscripten` into a single job using a matrix strategy.