### PR TITLE
Add missing `Storable (StablePtr a)` instance

### DIFF
--- a/lib/Foreign/StablePtr.hs
+++ b/lib/Foreign/StablePtr.hs
@@ -7,12 +7,15 @@ module Foreign.StablePtr(
   castPtrToStablePtr,
   ) where
 import qualified Prelude()
+import Mhs.Builtin
 import MiniPrelude
 import Primitives
 import Data.Typeable
+import Foreign.Storable
 
 newtype StablePtr a = StablePtr Word
   deriving (Typeable)
+  deriving newtype (Storable)
 
 instance Eq (StablePtr a) where
   StablePtr a == StablePtr a'  =  a == a'


### PR DESCRIPTION
Since `StablePtr a` is a newtype over `Word` with no additional invariants, we can use newtype deriving to implement the `Storable` instance.

With this change, the `Foreign.StablePtr` is report compliant.