### PR TITLE
Make `Numeric` report compliant

### DIFF
--- a/lib/Numeric.hs
+++ b/lib/Numeric.hs
@@ -57,52 +57,38 @@ fromRat (n :% d) | n > 0     = fromRat' (n :% d)
                  | n < 0     = - fromRat' ((-n) :% d)
                  | otherwise = encodeFloat 0 0             -- Zero
 
--- Conversion process:
--- Scale the rational number by the RealFloat base until
--- it lies in the range of the mantissa (as used by decodeFloat/encodeFloat).
--- Then round the rational to an Integer and encode it with the exponent
--- that we got from the scaling.
--- To speed up the scaling process we compute the log2 of the number to get
--- a first guess of the exponent.
-
 fromRat' :: (RealFloat a) => Rational -> a
 -- Invariant: argument is strictly positive
 fromRat' x = r
-  where b = floatRadix r
-        p = floatDigits r
-        (minExp0, _) = floatRange r
-        minExp = minExp0 - p            -- the real minimum exponent
-        xMax   = toRational (b ^ p)
-        ln     = integerLogBase b (numerator x)
-        ld     = integerLogBase b (denominator x)
-        p0     = (ln - ld - p) `max` minExp
-        -- if x = n/d and ln = integerLogBase b n, ld = integerLogBase b d,
-        -- then b^(ln-ld-1) < x < b^(ln-ld+1)
-        f = if p0 < 0 then 1 :% (b ^ (-p0)) else (b ^ p0) :% 1
-        x0 = x / f
-        -- if ln - ld >= minExp0, then b^(p-1) < x0 < b^(p+1), so there's at most
-        -- one scaling step needed, otherwise, x0 < b^p and no scaling is needed
-        (x', p') = if x0 >= xMax then (x0 / toRational b, p0+1) else (x0, p0)
-        r = encodeFloat (round x') p'
-
-wordLog2 :: Word -> Int
-wordLog2 w = _wordSize - 1 - primWordClz w
-
-integerLog2 :: Integer -> Int
-integerLog2 (I sign ds) =
-  case sign of
-    Minus -> 0 :: Int
-    Plus -> go ds 0
   where
-    go [] _ = 0 :: Int
-    go [d] i = wordLog2 d + (i `primIntShl` shiftD)
-    go (d : ds) i = go ds (i + 1)
+    n = numerator x
+    d = denominator x
+    b = floatRadix r
+    p = floatDigits r
+    (minExp, _) = floatRange r
+    maxVal = b ^ p
+    r =
+      if n < maxVal && d < maxVal then
+        -- no scaling needed
+        encodeFloat n 0 / encodeFloat d 0
+      else
+        let
+          ln = integerLogBase b n
+          ld = integerLogBase b d
+          -- b^(ln-ld-1) < x < b^(ln-ld+1)
+          p0 = max (ln - ld) minExp - p
+          f = if p0 < 0 then 1 :% (b ^ (-p0)) else (b ^ p0) :% 1
+          x0 = x / f
+          -- if ln - ld >= minExp, then b^(p-1) < x0 < b^(p+1), so there's at most
+          -- one scaling step needed, otherwise, x0 < b^p and no scaling is needed
+          (x', p') = if x0 >= toRational maxVal then (x0 / toRational b, p0 + 1) else (x0, p0)
+        in encodeFloat (round x') p'
 
+-- @integerLogBase b i@ is the logarithm of @i@ to base @b@, rounded down.
 integerLogBase :: Integer -> Integer -> Int
 integerLogBase b i
   | i == 0 = 0 :: Int
   | b < 2 = error "invalid base"
-  | b == 2 = integerLog2 i
   | otherwise = case go b of (_, e) -> e
   where
     go p = if i < p

--- a/lib/Numeric.hs
+++ b/lib/Numeric.hs
@@ -1,14 +1,51 @@
 module Numeric(
-  module Numeric.Show,
-
+  showSigned,
+  showIntAtBase,
+  showInt,
+  showBin,
+  showHex,
+  showOct,
+  showEFloat,--
+  showFFloat,
+  showGFloat,
+  showFloat,
+  floatToDigits,
   readSigned,
   readInt,
   readBin,
   readDec,
   readOct,
   readHex,
-  readIntegral,
+  readFloat,
+  lexDigits,
+  fromRat,
   ) where
-import qualified Prelude()              -- do not import Prelude
+import qualified Prelude() -- do not import Prelude
+import Control.Monad
+import Data.Fractional
+import Data.Function
+import Data.Ratio_Type (Rational)
+import Data.RealFloat (RealFloat)
+import Data.RealFrac (RealFrac)
+import Numeric.FormatFloat
 import Numeric.Read
 import Numeric.Show
+import Text.ParserCombinators.ReadP (ReadP, pfail, readP_to_S)
+import Text.Read.Internal (ReadS, lexDigits)
+import qualified Text.Read.Lex as L
+
+-- | Reads an /unsigned/ 'RealFrac' value,
+-- expressed in decimal scientific notation.
+readFloat :: RealFrac a => ReadS a
+readFloat = readP_to_S readFloatP
+
+readFloatP :: RealFrac a => ReadP a
+readFloatP =
+  do tok <- L.lex
+     case tok of
+       L.Number n -> return $ fromRational $ L.numberToRational n
+       _          -> pfail
+
+-- | Converts a 'Rational' value into any type in class 'RealFloat'.
+fromRat :: (RealFloat a) => Rational -> a
+fromRat = fromRational

--- a/lib/Numeric.hs
+++ b/lib/Numeric.hs
@@ -20,13 +20,12 @@ module Numeric(
   lexDigits,
   fromRat,
   ) where
-import qualified Prelude() -- do not import Prelude
-import Control.Monad
-import Data.Fractional
-import Data.Function
-import Data.Ratio_Type (Rational)
-import Data.RealFloat (RealFloat)
-import Data.RealFrac (RealFrac)
+
+import Primitives
+import Data.Integer_Type
+import Data.Integer.Internal
+import Data.Ratio_Type
+import Data.Ratio
 import Numeric.FormatFloat
 import Numeric.Read
 import Numeric.Show
@@ -48,4 +47,67 @@ readFloatP =
 
 -- | Converts a 'Rational' value into any type in class 'RealFloat'.
 fromRat :: (RealFloat a) => Rational -> a
-fromRat = fromRational
+
+-- Deal with special cases first, delegating the real work to fromRat'
+fromRat (n :% 0) | n > 0 =  1/0        -- +Infinity
+                 | n < 0 = -1/0        -- -Infinity
+                 | True  =  0/0        -- NaN
+
+fromRat (n :% d) | n > 0 = fromRat' (n :% d)
+                 | n < 0 = - fromRat' ((-n) :% d)
+                 | True  = encodeFloat 0 0             -- Zero
+
+-- Conversion process:
+-- Scale the rational number by the RealFloat base until
+-- it lies in the range of the mantissa (as used by decodeFloat/encodeFloat).
+-- Then round the rational to an Integer and encode it with the exponent
+-- that we got from the scaling.
+-- To speed up the scaling process we compute the log2 of the number to get
+-- a first guess of the exponent.
+
+fromRat' :: (RealFloat a) => Rational -> a
+-- Invariant: argument is strictly positive
+fromRat' x = r
+  where b = floatRadix r
+        p = floatDigits r
+        (minExp0, _) = floatRange r
+        minExp = minExp0 - p            -- the real minimum exponent
+        xMax   = toRational (b ^ p)
+        ln     = integerLogBase b (numerator x)
+        ld     = integerLogBase b (denominator x)
+        p0     = (ln - ld - p) `max` minExp
+        -- if x = n/d and ln = integerLogBase b n, ld = integerLogBase b d,
+        -- then b^(ln-ld-1) < x < b^(ln-ld+1)
+        f = if p0 < 0 then 1 :% (b ^ (-p0)) else (b ^ p0) :% 1
+        x0 = x / f
+        -- if ln - ld >= minExp0, then b^(p-1) < x0 < b^(p+1), so there's at most
+        -- one scaling step needed, otherwise, x0 < b^p and no scaling is needed
+        (x', p') = if x0 >= xMax then (x0 / toRational b, p0+1) else (x0, p0)
+        r = encodeFloat (round x') p'
+
+wordLog2 :: Word -> Int
+wordLog2 w = _wordSize - 1 - primWordClz w
+
+integerLog2 :: Integer -> Int
+integerLog2 (I sign ds) =
+  case sign of
+    Minus -> (0 :: Int)
+    Plus -> go ds 0
+  where
+    go [] _ = (0 :: Int)
+    go [d] i = wordLog2 d + (i `primIntShl` shiftD)
+    go (d : ds) i = go ds (i + 1)
+
+integerLogBase :: Integer -> Integer -> Int
+integerLogBase b i
+  | i == 0 = (0 :: Int)
+  | b < 2 = error "invalid base"
+  | b == 2 = integerLog2 i
+  | otherwise = case go b of (_, e) -> e
+  where
+    go p = if i < p
+      then (i, 0)
+      else case go (p * p) of
+        (q, e) -> if q < p
+          then (q, 2 * e)
+          else (q `quot` p, 2 * e + 1)

--- a/lib/Numeric.hs
+++ b/lib/Numeric.hs
@@ -49,13 +49,13 @@ readFloatP =
 fromRat :: (RealFloat a) => Rational -> a
 
 -- Deal with special cases first, delegating the real work to fromRat'
-fromRat (n :% 0) | n > 0 =  1/0        -- +Infinity
-                 | n < 0 = -1/0        -- -Infinity
-                 | True  =  0/0        -- NaN
+fromRat (n :% 0) | n > 0     =   1/0       -- +Infinity
+                 | n < 0     = -(1/0)      -- -Infinity
+                 | otherwise =   0/0       -- NaN
 
-fromRat (n :% d) | n > 0 = fromRat' (n :% d)
-                 | n < 0 = - fromRat' ((-n) :% d)
-                 | True  = encodeFloat 0 0             -- Zero
+fromRat (n :% d) | n > 0     = fromRat' (n :% d)
+                 | n < 0     = - fromRat' ((-n) :% d)
+                 | otherwise = encodeFloat 0 0             -- Zero
 
 -- Conversion process:
 -- Scale the rational number by the RealFloat base until
@@ -91,16 +91,16 @@ wordLog2 w = _wordSize - 1 - primWordClz w
 integerLog2 :: Integer -> Int
 integerLog2 (I sign ds) =
   case sign of
-    Minus -> (0 :: Int)
+    Minus -> 0 :: Int
     Plus -> go ds 0
   where
-    go [] _ = (0 :: Int)
+    go [] _ = 0 :: Int
     go [d] i = wordLog2 d + (i `primIntShl` shiftD)
     go (d : ds) i = go ds (i + 1)
 
 integerLogBase :: Integer -> Integer -> Int
 integerLogBase b i
-  | i == 0 = (0 :: Int)
+  | i == 0 = 0 :: Int
   | b < 2 = error "invalid base"
   | b == 2 = integerLog2 i
   | otherwise = case go b of (_, e) -> e

--- a/lib/Numeric/FormatFloat.hs
+++ b/lib/Numeric/FormatFloat.hs
@@ -10,6 +10,7 @@ module Numeric.FormatFloat(
   showGFloatAlt,
   showHFloat,
 
+  floatToDigits,
   ) where
 import qualified Prelude()
 import MiniPrelude

--- a/lib/Numeric/Read.hs
+++ b/lib/Numeric/Read.hs
@@ -22,6 +22,7 @@ import Data.List
 import Data.Maybe_Type
 import Data.Num
 import Data.Ord
+import Data.Real
 import Data.String
 import {-# SOURCE #-} Text.Read.Internal(lex)
 import Text.Show
@@ -58,7 +59,7 @@ readDec = readInt 10 isDigit digitToInt
 readHex :: forall a . (Num a) => ReadS a
 readHex = readInt 16 isHexDigit digitToInt
 
-readSigned :: forall a . (Num a) => ReadS a -> ReadS a
+readSigned :: forall a . (Real a) => ReadS a -> ReadS a
 readSigned readPos = readParen False read'
   where
     read' :: ReadS a

--- a/lib/Numeric/Show.hs
+++ b/lib/Numeric/Show.hs
@@ -19,12 +19,13 @@ import Data.Integral
 import Data.List
 import Data.Num
 import Data.Ord
+import Data.Real
 import Text.Show(ShowS, showChar)
 
-showSigned :: forall a . (Ord a, Num a) => (a -> ShowS) -> Int -> a -> ShowS
+showSigned :: (Real a) => (a -> ShowS) -> Int -> a -> ShowS
 showSigned = showSignedNeg (< 0)
 
-showSignedNeg :: forall a . (Ord a, Num a) => (a -> Bool) -> (a -> ShowS) -> Int -> a -> ShowS
+showSignedNeg :: (Real a) => (a -> Bool) -> (a -> ShowS) -> Int -> a -> ShowS
 showSignedNeg isNeg showPos p n r
     | isNeg n =
       if p > (6::Int) then
@@ -37,7 +38,7 @@ showSignedNeg isNeg showPos p n r
 -- first argument, and the character representation specified by the second.
 -- If the argument, n, is <0 and -n == n (i.e., n == minBound) it will
 -- return the string for (abs n).
-showIntAtBase :: forall a . (Ord a, Integral a) => a -> (Int -> Char) -> a -> ShowS
+showIntAtBase :: (Integral a) => a -> (Int -> Char) -> a -> ShowS
 showIntAtBase base toChr an
   | base <= 1 = error "Numeric.showIntAtBase: unsupported base"
   | an < 0 =
@@ -57,17 +58,17 @@ showIntAtBase base toChr an
           else
             showPos (quot n base) (c : r)
 
-showInt :: forall a . (Ord a, Integral a) => a -> ShowS
+showInt :: (Integral a) => a -> ShowS
 showInt = showIntAtBase 10 intToDigit
 
-showHex :: forall a . (Ord a, Integral a) => a -> ShowS
+showHex :: (Integral a) => a -> ShowS
 showHex = showIntAtBase 16 intToDigit
 
-showOct :: forall a . (Ord a, Integral a) => a -> ShowS
+showOct :: (Integral a) => a -> ShowS
 showOct = showIntAtBase 8  intToDigit
 
-showBin :: forall a . (Ord a, Integral a) => a -> ShowS
+showBin :: (Integral a) => a -> ShowS
 showBin = showIntAtBase 2  intToDigit
 
-showIntegral :: forall a . (Ord a, Integral a) => Int -> a -> ShowS
+showIntegral :: (Integral a) => Int -> a -> ShowS
 showIntegral = showSigned showInt


### PR DESCRIPTION
Make `Numeric` report compliant by exporting more functions that were already there and newly defining `readFloat` and `fromRat`. The `readFloat` code is taken verbatim from GHC base, the `fromRat` implementation is adapted from the GHC version. `Numeric` now imports `Prelude`, since I didn't want to write down all the needed imports, I hope that's okay .