### PR TITLE
Fix GMP conversion functions

### DIFF
--- a/lib/gmp/Data/Integer_Type.hs
+++ b/lib/gmp/Data/Integer_Type.hs
@@ -29,8 +29,7 @@ newtype Integer = I (ForeignPtr MPZ)
 foreign import capi "new_mpz"         new_mpz         :: IO (Ptr MPZ)  -- it really returns a ForeignPtr
 foreign import capi "mpz_init_set_si" mpz_init_set_si :: Ptr MPZ -> Int -> IO ()
 foreign import capi "mpz_init_set_ui" mpz_init_set_ui :: Ptr MPZ -> Word -> IO ()
---foreign import capi "mpz_get_si"      mpz_get_si      :: Ptr MPZ -> IO Int
-foreign import capi "mpz_get_ui"      mpz_get_ui      :: Ptr MPZ -> IO Word
+foreign import capi "mpz_get_si"      mpz_get_si      :: Ptr MPZ -> IO Int
 foreign import capi "mpz_get_f"       mpz_get_f       :: Ptr MPZ -> IO Float
 foreign import capi "mpz_get_d"       mpz_get_d       :: Ptr MPZ -> IO Double
 
@@ -54,15 +53,10 @@ _wordToInteger i = primPerformIO (do
   )
 
 _integerToInt :: Integer -> Int
-_integerToInt i@(I _x) =
-  -- This code is "wrong", if x=0x8000_0000_0000_0000 then
-  -- mpz_get_si will return 0, but mhs relies on it wrapping.
-  --   primPerformIO (withForeignPtr x mpz_get_si)
-  -- So instead we go via the unsigned version.
-  primWordToInt (_integerToWord i)
+_integerToInt (I x) = primPerformIO (withForeignPtr x mpz_get_si)
 
 _integerToWord :: Integer -> Word
-_integerToWord (I x) = primPerformIO (withForeignPtr x mpz_get_ui)
+_integerToWord i = primIntToWord (_integerToInt i)
 
 _integerToFloat :: Integer -> Float
 _integerToFloat (I x) = primPerformIO (withForeignPtr x mpz_get_f)
@@ -74,15 +68,13 @@ _integerToDouble (I x) = primPerformIO (withForeignPtr x mpz_get_d)
 
 foreign import capi "mpz_init_set_si64" mpz_init_set_si64 :: Ptr MPZ -> Int64 -> IO ()
 foreign import capi "mpz_init_set_ui64" mpz_init_set_ui64 :: Ptr MPZ -> Word64 -> IO ()
---foreign import capi "mpz_get_si64"      mpz_get_si64      :: Ptr MPZ -> IO Int64
-foreign import capi "mpz_get_ui64"      mpz_get_ui64      :: Ptr MPZ -> IO Word64
+foreign import capi "mpz_get_si64"      mpz_get_si64      :: Ptr MPZ -> IO Int64
 
 _integerToInt64 :: Integer -> Int64
---_integerToInt64 (I x) = chk64 $ primPerformIO (withForeignPtr x mpz_get_si64)
-_integerToInt64 i = primWord64ToInt64 (_integerToWord64 i)
+_integerToInt64 (I x) = primPerformIO (withForeignPtr x mpz_get_si64)
 
 _integerToWord64 :: Integer -> Word64
-_integerToWord64 (I x) = primPerformIO (withForeignPtr x mpz_get_ui64)
+_integerToWord64 i = primInt64ToWord64 (_integerToInt64 i)
 
 _word64ToInteger :: Word64 -> Integer
 _word64ToInteger i = primPerformIO (do

--- a/src/MicroHs/FFI.hs
+++ b/src/MicroHs/FFI.hs
@@ -313,10 +313,10 @@ runtimeFFI = [
   "getcpu",
   "get_mem", "openb_rd_mem", "openb_wr_mem",
   "new_mpz", "mpz_abs", "mpz_add", "mpz_and", "mpz_cmp", "mpz_get_d", "mpz_get_f",
-  "mpz_get_si", "mpz_get_ui", "mpz_init_set_si", "mpz_init_set_ui",
+  "mpz_get_si", "mpz_init_set_si", "mpz_init_set_ui",
   "mpz_ior",
   "mpz_mul", "mpz_mul_2exp", "mpz_neg", "mpz_popcount", "mpz_sub", "mpz_fdiv_q_2exp",
   "mpz_tdiv_qr", "mpz_tstbit", "mpz_xor",
-  "mpz_get_si64", "mpz_get_ui64", "mpz_init_set_si64", "mpz_init_set_ui64",
+  "mpz_get_si64", "mpz_init_set_si64", "mpz_init_set_ui64",
   "want_gmp"
   ]

--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -6832,9 +6832,12 @@ print_mpz(mpz_ptr p)
 void
 mpz_init_set_si64(mpz_t rop, int64_t op)
 {
-  mpz_init_set_si(rop, op >> 32);
-  mpz_mul_2exp(rop, rop, 32);
-  mpz_add_ui(rop, rop, op & 0xffffffff);
+  if (op >= 0) {
+    mpz_init_set_ui64(rop, op);
+  } else {
+    mpz_init_set_ui64(rop, -op);
+    mpz_neg(rop, rop);
+  }
 }
 void
 mpz_init_set_ui64(mpz_t rop, uint64_t op)
@@ -6843,36 +6846,25 @@ mpz_init_set_ui64(mpz_t rop, uint64_t op)
   mpz_mul_2exp(rop, rop, 32);
   mpz_add_ui(rop, rop, op & 0xffffffff);
 }
-uint64_t
-mpz_get_ui64(mpz_t op)
-{
-  mpz_t t;
-  mpz_init_set(t, op);
-  mpz_fdiv_q_2exp(t, t, 32);
-  uint64_t hi = mpz_get_ui(t);
-  uint64_t lo = mpz_get_ui(op);
-  mpz_clear(t);
-  return (hi << 32) | lo;
-}
 int64_t
 mpz_get_si64(mpz_t op)
 {
-  if (mpz_sgn(op) >= 0)
-    return mpz_get_ui64(op);
-  else {
-    mpz_t t;
-    mpz_init_set(t, op);
-    mpz_neg(t, t);
-    uint64_t r = mpz_get_ui64(t);
-    mpz_clear(t);
-    return -(int64_t)r;
+  mpz_t t;
+  mpz_init_set(t, op);
+  mpz_tdiv_q_2exp(t, t, 32);
+  uint64_t hi = mpz_get_ui(t);
+  uint64_t lo = mpz_get_ui(op);
+  mpz_clear(t);
+  uint64_t r = (hi << 32) | lo;
+  if (mpz_sgn(op) < 0) {
+    r = -r;
   }
+  return r;
 }
 #endif  /* NEED_INT64 */
 #if WORD_SIZE == 64
 #define mpz_init_set_ui64 mpz_init_set_ui
 #define mpz_init_set_si64 mpz_init_set_si
-#define mpz_get_ui64 mpz_get_ui
 #define mpz_get_si64 mpz_get_si
 #define mhs_to_Int64 mhs_to_Int
 #define mhs_to_Word64 mhs_to_Word
@@ -6889,8 +6881,14 @@ from_t mhs_mpz_and(int s) { mpz_and(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_P
 from_t mhs_mpz_cmp(int s) { return mhs_from_Int(s, 2, mpz_cmp(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1))); }
 from_t mhs_mpz_get_d(int s) { return mhs_from_Double(s, 1, mpz_get_d(mhs_to_Ptr(s, 0))); }
 from_t mhs_mpz_get_f(int s) { return mhs_from_Float(s, 1, (float)mpz_get_d(mhs_to_Ptr(s, 0))); }
-from_t mhs_mpz_get_si(int s) { return mhs_from_Int(s, 1, mpz_get_si(mhs_to_Ptr(s, 0))); }
-from_t mhs_mpz_get_ui(int s) { return mhs_from_Word(s, 1, mpz_get_ui(mhs_to_Ptr(s, 0))); }
+from_t mhs_mpz_get_si(int s) {
+  mpz_ptr a = mhs_to_Ptr(s, 0);
+  value_t r = mpz_get_ui(a);
+  if (mpz_sgn(a) < 0) {
+    r = -r;
+  }
+  return mhs_from_Int(s, 1, r);
+}
 from_t mhs_mpz_init_set_si(int s) { mpz_init_set_si(mhs_to_Ptr(s, 0), mhs_to_Int(s, 1)); return mhs_from_Unit(s, 2); }
 from_t mhs_mpz_init_set_ui(int s) { mpz_init_set_ui(mhs_to_Ptr(s, 0), mhs_to_Word(s, 1)); return mhs_from_Unit(s, 2); }
 from_t mhs_mpz_ior(int s) { mpz_ior(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Ptr(s, 2)); return mhs_from_Unit(s, 3); }
@@ -6899,16 +6897,17 @@ from_t mhs_mpz_mul_2exp(int s) { mpz_mul_2exp(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1)
 from_t mhs_mpz_neg(int s) { mpz_neg(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1)); return mhs_from_Unit(s, 2); }
 from_t mhs_mpz_popcount(int s) {
   mpz_ptr a = mhs_to_Ptr(s, 0);
+  from_t r;
   if (mpz_sgn(a) < 0) {
     mpz_t neg_a;
     mpz_init(neg_a);
     mpz_neg(neg_a, a);
-    (void)mhs_from_Int(s, 1, -mpz_popcount(neg_a));
+    r = mhs_from_Int(s, 1, -mpz_popcount(neg_a));
     mpz_clear(neg_a);
   } else {
-    (void)mhs_from_Int(s, 1, mpz_popcount(a));
+    r = mhs_from_Int(s, 1, mpz_popcount(a));
   }
-  return 1;
+  return r;
 }
 from_t mhs_mpz_sub(int s) { mpz_sub(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Ptr(s, 2)); return mhs_from_Unit(s, 3); }
 from_t mhs_mpz_fdiv_q_2exp(int s) { mpz_fdiv_q_2exp(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Int(s, 2)); return mhs_from_Unit(s, 3); }
@@ -6918,7 +6917,6 @@ from_t mhs_mpz_xor(int s) { mpz_xor(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_P
 from_t mhs_mpz_init_set_si64(int s) { mpz_init_set_si64(mhs_to_Ptr(s, 0), mhs_to_Int64(s, 1)); return mhs_from_Unit(s, 2); }
 from_t mhs_mpz_init_set_ui64(int s) { mpz_init_set_ui64(mhs_to_Ptr(s, 0), mhs_to_Word64(s, 1)); return mhs_from_Unit(s, 2); }
 from_t mhs_mpz_get_si64(int s) { return mhs_from_Int64(s, 1, mpz_get_si64(mhs_to_Ptr(s, 0))); }
-from_t mhs_mpz_get_ui64(int s) { return mhs_from_Word64(s, 1, mpz_get_ui64(mhs_to_Ptr(s, 0))); }
 #endif  /* WANT_GMP */
 
 const struct ffi_entry ffi_table[] = {
@@ -7101,7 +7099,6 @@ const struct ffi_entry ffi_table[] = {
   { "mpz_cmp", 2, mhs_mpz_cmp},
   { "mpz_get_d", 1, mhs_mpz_get_d},
   { "mpz_get_si", 1, mhs_mpz_get_si},
-  { "mpz_get_ui", 1, mhs_mpz_get_ui},
   { "mpz_init_set_si", 2, mhs_mpz_init_set_si},
   { "mpz_init_set_ui", 2, mhs_mpz_init_set_ui},
   { "mpz_ior", 3, mhs_mpz_ior},
@@ -7118,7 +7115,6 @@ const struct ffi_entry ffi_table[] = {
   { "mpz_init_set_si64", 2, mhs_mpz_init_set_si64},
   { "mpz_init_set_ui64", 2, mhs_mpz_init_set_ui64},
   { "mpz_get_si64", 1, mhs_mpz_get_si64},
-  { "mpz_get_ui64", 1, mhs_mpz_get_ui64},
 #endif  /* WANT_GMP */
   { 0,0 }
 };

--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -6819,6 +6819,16 @@ new_mpz(void)
   return fp;
 }
 
+intptr_t
+mpz_get_si_(mpz_t op)
+{
+  intptr_t r = mpz_get_ui(op);
+  if (mpz_sgn(op) < 0) {
+    r = -r;
+  }
+  return r;
+}
+
 #if 0
 void
 print_mpz(mpz_ptr p)
@@ -6865,7 +6875,7 @@ mpz_get_si64(mpz_t op)
 #if WORD_SIZE == 64
 #define mpz_init_set_ui64 mpz_init_set_ui
 #define mpz_init_set_si64 mpz_init_set_si
-#define mpz_get_si64 mpz_get_si
+#define mpz_get_si64 mpz_get_si_
 #define mhs_to_Int64 mhs_to_Int
 #define mhs_to_Word64 mhs_to_Word
 #define mhs_from_Int64 mhs_from_Int
@@ -6881,14 +6891,7 @@ from_t mhs_mpz_and(int s) { mpz_and(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_P
 from_t mhs_mpz_cmp(int s) { return mhs_from_Int(s, 2, mpz_cmp(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1))); }
 from_t mhs_mpz_get_d(int s) { return mhs_from_Double(s, 1, mpz_get_d(mhs_to_Ptr(s, 0))); }
 from_t mhs_mpz_get_f(int s) { return mhs_from_Float(s, 1, (float)mpz_get_d(mhs_to_Ptr(s, 0))); }
-from_t mhs_mpz_get_si(int s) {
-  mpz_ptr a = mhs_to_Ptr(s, 0);
-  value_t r = mpz_get_ui(a);
-  if (mpz_sgn(a) < 0) {
-    r = -r;
-  }
-  return mhs_from_Int(s, 1, r);
-}
+from_t mhs_mpz_get_si(int s) { return mhs_from_Int(s, 1, mpz_get_si_(mhs_to_Ptr(s, 0))); }
 from_t mhs_mpz_init_set_si(int s) { mpz_init_set_si(mhs_to_Ptr(s, 0), mhs_to_Int(s, 1)); return mhs_from_Unit(s, 2); }
 from_t mhs_mpz_init_set_ui(int s) { mpz_init_set_ui(mhs_to_Ptr(s, 0), mhs_to_Word(s, 1)); return mhs_from_Unit(s, 2); }
 from_t mhs_mpz_ior(int s) { mpz_ior(mhs_to_Ptr(s, 0), mhs_to_Ptr(s, 1), mhs_to_Ptr(s, 2)); return mhs_from_Unit(s, 3); }

--- a/tests/Integer.hs
+++ b/tests/Integer.hs
@@ -1,4 +1,5 @@
 module Integer(main) where
+
 import Data.Bits
 import Data.Int
 import Data.Word
@@ -7,7 +8,6 @@ import System.IO.StringHandle
 
 main :: IO ()
 main = do
-{-
   print $ (1000::Integer) == 1000
   print $ ((10::Integer)^(100::Int)) /= 0
   print $ show (product [1..100::Integer]) == "93326215443944152681699238856266700490715968264381621468592963895217599993229915608941463976156518286253697920827223758251185210916864000000000000000000000000"
@@ -17,7 +17,7 @@ main = do
   h <- stringToHandle s
   i' <- hDeserialize h
   print $ i == i'
--}
+
   -- Integer conversion
   let
     iMinI64 = -9223372036854775808
@@ -30,12 +30,11 @@ main = do
     iMaxI64 = 9223372036854775807
     iMaxU64 = 18446744073709551615
   putStrLn "fromInteger"
---  print $ (fromInteger iMinI64 :: Int64) == (minBound :: Int64)
---  print $ (fromInteger iMinI64 :: Int32) == 0
---  print $ (fromInteger iMinI64 :: Word64) == 1 `shiftL` 63
---  print $ (fromInteger iMinI64 :: Word32) == 0
+  print $ (fromInteger iMinI64 :: Int64) == (minBound :: Int64)
+  print $ (fromInteger iMinI64 :: Int32) == 0
+  print $ (fromInteger iMinI64 :: Word64) == 1 `shiftL` 63
+  print $ (fromInteger iMinI64 :: Word32) == 0
   print $ (fromInteger iMinI32 :: Int64) == complement ((1 `shiftL` 31) - 1)
-{-
   print $ (fromInteger iMinI32 :: Int32) == (minBound :: Int32)
   print $ (fromInteger iMinI32 :: Word64) == complement ((1 `shiftL` 31) - 1)
   print $ (fromInteger iMinI32 :: Word32) == 1 `shiftL` 31
@@ -84,4 +83,3 @@ main = do
   print $ toInteger (maxBound :: Int32) == iMaxI32
   print $ toInteger (maxBound :: Word64) == iMaxU64
   print $ toInteger (maxBound :: Word32) == iMaxU32
--}


### PR DESCRIPTION
`mpz_get_ui` ignores the sign, so it gets the least significant bits of the absolute value, which is not the behaviour we want. Instead, I modified `mpz_get_si` to properly handle `maxBound :: Int`.
Similarly, I changed `mpz_get_si64` to use the code of `mpz_get_ui64`, with the small change to use `mpz_tdiv_q_2exp` (logical right shift) instead of `mpz_fdiv_q_2exp` (arithmetic right shift), to get the absolute value (which is then negated if the input was negative).
`mpz_init_set_si64` was also broken for negative values, so I changed it to use `mpz_init_set_ui64` and negate the result if the input was negative.