### PR TITLE
Make `Data.Complex` (more or less) report compliant

### DIFF
--- a/lib/Data/Complex.hs
+++ b/lib/Data/Complex.hs
@@ -90,21 +90,21 @@ instance (RealFloat a) => Floating (Complex a) where
                       where expx = exp x
     log z          =  log (magnitude z) :+ phase z
 
-    x ** y = case (x,y) of
-      (_ , (0:+0))  -> 1 :+ 0
-      ((0:+0), (exp_re:+_)) -> case compare exp_re 0 of
-                 GT -> 0 :+ 0
-                 LT -> inf :+ 0
-                 EQ -> nan :+ nan
-      ((re:+im), (exp_re:+_))
-        | (isInfinite re || isInfinite im) -> case compare exp_re 0 of
-                 GT -> inf :+ 0
-                 LT -> 0 :+ 0
-                 EQ -> nan :+ nan
+    x ** y = case (x, y) of
+      (_ , 0 :+ 0) -> 1 :+ 0
+      (0 :+ 0, exp_re :+ _) -> case compare exp_re 0 of
+        GT -> 0 :+ 0
+        LT -> inf :+ 0
+        EQ -> nan :+ nan
+      (re :+ im, exp_re :+ _)
+        | isInfinite re || isInfinite im -> case compare exp_re 0 of
+            GT -> inf :+ 0
+            LT -> 0 :+ 0
+            EQ -> nan :+ nan
         | otherwise -> exp (log x * y)
      where
-        inf = 1/0
-        nan = 0/0
+        inf = 1 / 0
+        nan = 0 / 0
     sqrt (0:+0)    =  0
     sqrt z@(x:+y)  =  u :+ (if y < 0 then - v else v)
                       where (u,v) = if x < 0 then (v',u') else (u',v')


### PR DESCRIPTION
- Add a `Read` instance, based on what GHC would generate (since deriving wouldn't produce the correct instance yet)
- Fix the `Show` instance to consider precedence
- Add an export list
- Uncomment the `**` definition
- Use literal patterns (I assume the reason they were commented out is that they weren't supported when the module was added?)

With these changes, `Data.Complex` is (more or less report) compliant. Technically, the report has a `RealFloat a =>` datatype context, so every instance also requires that (and the `Show` instance doesn't require `Show a`). However, datatype contexts are widely considered a misfeature; they're deprecated in GHC and MicroHs doesn't support them at all. GHC just derives `Read` and `Show` (which generates the instances I added), so we should be good.