### PR TITLE
Consider whether constructors were written in infix notation when deriving `Show`/`Read`

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -59,6 +59,7 @@
 - ignore: {name: Use const, within: [Control.Exception.Internal]}
 - ignore: {name: Use writeList2Chan, within: [Control.Concurrent.Chan]}
 - ignore: {name: Redundant fromInteger, within: [FArith, DArith]}
+- ignore: {name: Use section, within: [Deriving]}
 
 - arguments:
     - --ignore-glob=lib/Data/Foldable1.hs

--- a/lib/Data/Complex.hs
+++ b/lib/Data/Complex.hs
@@ -18,19 +18,7 @@ import qualified Text.Read.Lex as L
 infix 6 :+
 
 data Complex a = !a :+ !a
-  deriving (Typeable, Eq)
-
-instance Read a => Read (Complex a) where
-  readPrec = parens $ prec 6 $ do
-    x <- step readPrec
-    expectP (L.Symbol ":+")
-    y <- step readPrec
-    return (x :+ y)
-  readList = readListDefault
-  readListPrec = readListPrecDefault
-
-instance Show a => Show (Complex a) where
-  showsPrec p (x :+ y) = showParen (p > 6) $ showsPrec 7 x . showString " :+ " . showsPrec 7 y
+  deriving (Typeable, Eq, Read, Show)
 
 realPart :: forall a . Complex a -> a
 realPart (x :+ _) =  x

--- a/src/MicroHs/Desugar.hs
+++ b/src/MicroHs/Desugar.hs
@@ -39,13 +39,13 @@ dsDef flags mn ffiNo adef =
     Data _ cs _ ->
       let
         n = length cs
-        dsConstr i (Constr _ ctx c ets) =
+        dsConstr i (Constr _ ctx c _ ets) =
           let
             ss = (if null ctx then [] else [False]) ++
                  map fst (either id (map snd) ets)   -- strict flags
           in (qualIdent mn c, encConstr i n ss)
       in  zipWith dsConstr [0::Int ..] cs
-    Newtype _ (Constr _ _ c _) _ -> [ (qualIdent mn c, Lit (LPrim "I")) ]
+    Newtype _ (Constr _ _ c _ _) _ -> [ (qualIdent mn c, Lit (LPrim "I")) ]
     Fcn f eqns -> [(f, wrapTick (useTicks flags) f $ dsEqns (getSLoc f) eqns)]
     ForImp cc ie i t -> [(i, ccall t $ Lit $ mkForImp ffiNo cc ie i t)]
     -- Foreign exports don't fit very well into the desugared syntax.

--- a/src/MicroHs/Expr.hs
+++ b/src/MicroHs/Expr.hs
@@ -452,11 +452,12 @@ type LHS = (Ident, [IdKind])
 data Constr = Constr
   [IdKind] [EConstraint]          -- existentials: forall vs . ctx =>
   Ident                           -- constructor name
+  Bool                            -- if the constructor is written in infix notation
   (Either [SType] [ConstrField])  -- types or named fields
   deriving(Show)
 
 instance NFData Constr where
-  rnf (Constr a b c d) = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
+  rnf (Constr a b c d e) = rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e
 
 type ConstrField = (Ident, SType)              -- record label and type
 type SType = (Bool, EType)                     -- the Bool indicates strict
@@ -905,7 +906,7 @@ ppEqns :: Doc -> Doc -> [Eqn] -> Doc
 ppEqns name sepr = vcat . map (\ (Eqn ps alts) -> sep [name <+> hsep (map ppEPat ps), ppAlts sepr alts])
 
 ppConstr :: Constr -> Doc
-ppConstr (Constr iks ct c cs) = ppForall QImpl iks <+> ppCtx ct <+> ppIdent c <+> ppCs cs
+ppConstr (Constr iks ct c _ cs) = ppForall QImpl iks <+> ppCtx ct <+> ppIdent c <+> ppCs cs
   where ppCs (Left  ts) = hsep (map ppSType ts)
         ppCs (Right fs) = braces (hsep $ map f fs)
           where f (i, t) = ppIdent i <+> text "::" <+> ppSType t <> text ","

--- a/src/MicroHs/Fixity.hs
+++ b/src/MicroHs/Fixity.hs
@@ -1,4 +1,4 @@
-module MicroHs.Fixity(resolveFixity) where
+module MicroHs.Fixity(defaultFixity, resolveFixity) where
 import qualified Prelude(); import MHSPrelude
 import MicroHs.Builtin
 import MicroHs.Expr
@@ -39,6 +39,9 @@ data Fix = FixIn | FixPre
 
 data FixInput = Rator Fix Expr Fixity | Rand Expr
 --  deriving (Show)
+
+defaultFixity :: Fixity
+defaultFixity = (AssocLeft, 9)
 
 eNeg :: SLoc -> Expr
 eNeg loc = EVar (mkBuiltin loc "negate")

--- a/src/MicroHs/TypeCheck.hs
+++ b/src/MicroHs/TypeCheck.hs
@@ -1059,8 +1059,8 @@ addAssocs adef = do
               _       -> impossibleShow i
       addAssocTable (qualIdent mn ti) (map val is)
 
-    assocData (Constr _ _ c (Left _)) = [c]
-    assocData (Constr _ _ c (Right its)) = c : map fst its
+    assocData (Constr _ _ c _ (Left _)) = [c]
+    assocData (Constr _ _ c _ (Right its)) = c : map fst its
 
   case adef of
     Data    (i, _) cs _ | not (isMatchDataTypeName i)
@@ -1183,10 +1183,10 @@ tcCtx :: HasCallStack => [EConstraint] -> T [EConstraint]
 tcCtx = mapM (tCheckTypeT kConstraint)
 
 tcConstr :: HasCallStack => Constr -> T Constr
-tcConstr (Constr iks ct c ets) =
+tcConstr (Constr iks ct c inf ets) =
   assertTCMode (==TCType) $
   withVks iks $ \ iks' ->
-    Constr iks' <$> tcCtx ct <*> pure c <*>
+    Constr iks' <$> tcCtx ct <*> pure c <*> pure inf <*>
       case ets of
         Left  x -> Left  <$> mapM (\ (s,t)     ->        (,)s <$> tcTypeT (Check kType) t) x
         Right x -> Right <$> mapM (\ (i,(s,t)) -> (,)i . (,)s <$> tcTypeT (Check kType) t) x
@@ -1436,8 +1436,8 @@ addValueType :: EDef -> T ()
 addValueType adef = do
   mn <- gets moduleName
   -- tcTrace ("addValueType: " ++ showEDefs [adef])
-  let addConFields _     (Constr _ _ _ (Left _)) = return ()
-      addConFields tycon (Constr _ _ _ (Right fs)) = mapM_ addField fs
+  let addConFields _     (Constr _ _ _ _ (Left _)) = return ()
+      addConFields tycon (Constr _ _ _ _ (Right fs)) = mapM_ addField fs
         where addField (fld, _) = do
                 (fe, fty) <- tLookup "???" $ mkGetName tycon fld
                 extValETop fld fty fe
@@ -1451,16 +1451,16 @@ addValueType adef = do
       mapM_ (\ i -> extValQTop i t) is
     Data (tycon, vks) cs _ -> do
       let
-        cti = [ (qualIdent mn c, either length length ets + if null ctx then 0 else 1) | Constr _ ctx c ets <- cs ]
+        cti = [ (qualIdent mn c, either length length ets + if null ctx then 0 else 1) | Constr _ ctx c _ ets <- cs ]
         tret = tApps (qualIdent mn tycon) (map tVarK vks)
-        addCon (Constr evks ectx c ets) = do
+        addCon (Constr evks ectx c _ ets) = do
           let ts = either id (map snd) ets
               cty = EForall QExpl vks $ EForall QExpl evks $ addConstraints ectx $ foldr (tArrow . snd) tret ts
               fs = either (const []) (map fst) ets
           extValETop c cty (ECon $ ConData cti (qualIdent mn c) fs)
       mapM_ addCon cs
       mapM_ (addConFields tycon) cs
-    Newtype (tycon, vks) con@(Constr _ _ c ets) _ -> do
+    Newtype (tycon, vks) con@(Constr _ _ c _ ets) _ -> do
       let
         t = snd $ head $ either id (map snd) ets
         tret = tApps (qualIdent mn tycon) (map tVarK vks)
@@ -2280,7 +2280,7 @@ unList (Check (EApp (EVar i) t)) | i == identList = Just t
 unList _ = Nothing
 
 getFixity :: FixTable -> Ident -> Fixity
-getFixity fixs i = fromMaybe (AssocLeft, 9) $ M.lookup i fixs
+getFixity fixs i = fromMaybe defaultFixity $ M.lookup i fixs
 
 newADictIdent :: SLoc -> T Ident
 newADictIdent loc = newIdent loc adictPrefix
@@ -2944,8 +2944,8 @@ mkMatchDataTypeConstr qi at =
 
       ddata = Data lhs [cm, cn] []
             where lhs = (unQualIdent tycon, vks1)
-                  cm = Constr vks2 (if isEmptyCtx ctx2 then [] else [ctx2]) (unQualIdent mi) (Left $ map ((,) False) ats)
-                  cn = Constr []   []                                       (unQualIdent ni) (Left [])
+                  cm = Constr vks2 (if isEmptyCtx ctx2 then [] else [ctx2]) (unQualIdent mi) False (Left $ map ((,) False) ats)
+                  cn = Constr []   []                                       (unQualIdent ni) False (Left [])
 
   in  -- trace ("M :: " ++ show tm ++ ",  N :: " ++ show tn) $
       -- trace (showEDefs [ddata]) $
@@ -3320,7 +3320,7 @@ solveInstCoercible loc iCls t1 t2 = do
 extNewtypeSyns :: T ()
 extNewtypeSyns = do
   dt <- gets dataTable
-  let ext (qi, Newtype (_, vs) (Constr _ _ _c et) _) = do
+  let ext (qi, Newtype (_, vs) (Constr _ _ _c _ et) _) = do
           -- XXX We should check that the constructor name (_c) is visible.
           -- But this is tricky since we don't know under what qualified name it
           -- it should be visible.

--- a/tests/Deriving.hs
+++ b/tests/Deriving.hs
@@ -1,6 +1,7 @@
 module Deriving(main) where
 import Data.Typeable
 import Data.Ix
+import Text.Read (readMaybe)
 
 data T a b c = A a | B b | C a Int | D
   deriving (Eq, Ord, Show, Read)
@@ -14,15 +15,21 @@ newtype Alt f a = Alt (f a)
 data E = X | Y | Z
   deriving (Enum, Bounded, Show, Eq, Ord, Ix, Typeable)
 
-data F = MkF Bool Int deriving (Show, Eq, Ord, Ix)
-
 -- Not yet
 -- data F a = F0 | F1 a | F2 (a,a) | F3 Int | F4 a Int | F5 (Int -> a)
 --   deriving Functor
 
---infixr 5 :^:
-data Tree a = Leaf a | (:^:) (Tree a) (Tree a)
+data Pair = MkPair Bool Int deriving (Show, Eq, Ord, Ix)
+
+infixr 5 :^:
+data Tree a = Leaf a | Tree a :^: Tree a
   deriving (Show, Read)
+
+infixr 5 `Cons`
+data List a = Nil | a `Cons` List a
+  deriving (Show, Read)
+
+newtype Op = (:::) () deriving (Read, Show)
 
 main :: IO ()
 main = do
@@ -124,14 +131,24 @@ main = do
   print $ inRange (Z, Y) Z
   print $ inRange (Z, Z) Z
 
-  -- Ix F
-  let r = (MkF False 2, MkF True 5)
+  -- Ix Pair
+  let r = (MkPair False 2, MkPair True 5)
   print $ range r
-  print $ unsafeIndex r (MkF True 3)
-  print $ inRange r (MkF True 3)
+  print $ unsafeIndex r (MkPair True 3)
+  print $ inRange r (MkPair True 3)
 
   print (Leaf 1 :^: Leaf 2 :: Tree Int)
-  print (read "(:^:) (Leaf 1) (Leaf 2)" :: Tree Int)
+  print (read "Leaf 1 :^: Leaf 2" :: Tree Int)
+  print (readMaybe "(:^:) (Leaf 1) (Leaf 2)" :: Maybe (Tree Int))
+
+  print (1 `Cons` 2 `Cons` Nil :: List Int)
+  print (read "1 `Cons` (2 `Cons` Nil)" :: List Int)
+  print (readMaybe "1 `Cons` 2 `Cons` Nil" :: Maybe (List Int))
+  print (readMaybe "Cons 1 (Cons 2 Nil)" :: Maybe (List Int))
+
+  print ((:::) ())
+  print (read "(:::) ()" :: Op)
+  print (readMaybe "::: ()" :: Maybe Op)
 
   -- Check that they all have Typeable
   print (typeOf (R True 1), X)

--- a/tests/Deriving.ref
+++ b/tests/Deriving.ref
@@ -88,9 +88,17 @@ True
 False
 False
 True
-[MkF False 2,MkF False 3,MkF False 4,MkF False 5,MkF True 2,MkF True 3,MkF True 4,MkF True 5]
+[MkPair False 2,MkPair False 3,MkPair False 4,MkPair False 5,MkPair True 2,MkPair True 3,MkPair True 4,MkPair True 5]
 5
 True
-(:^:) (Leaf 1) (Leaf 2)
-(:^:) (Leaf 1) (Leaf 2)
+Leaf 1 :^: Leaf 2
+Leaf 1 :^: Leaf 2
+Nothing
+1 `Cons` (2 `Cons` Nil)
+1 `Cons` (2 `Cons` Nil)
+Nothing
+Nothing
+(:::) ()
+(:::) ()
+Nothing
 (Rec Bool,X)


### PR DESCRIPTION
For this, I modified the parser to allow backticked constructors and fixed `pUOper`, which previously allows patterns like ``a `(,)` b = 42``. `Constr` now has a `(Ident, Bool)`, where the `Bool` indicates whether the constructor was written in infix notation. This is currently ignored in `ppConstr`.