### PR TITLE
Remove unneeded comparison

### DIFF
--- a/src/MicroHs/EncodeData.hs
+++ b/src/MicroHs/EncodeData.hs
@@ -25,8 +25,7 @@ encCase var pes dflt | n <= scottLimit = encCaseScott var pes dflt
   where n = numConstr pes
 
 encConstr :: Int -> Int -> [Bool] -> Exp
-encConstr i n ss | n /= n = undefined  -- XXX without this, everything slows down.  Why?
-                 | n <= scottLimit = encConstrScott i n ss
+encConstr i n ss | n <= scottLimit = encConstrScott i n ss
                  | otherwise       = encConstrNo i n ss
 
 encIf :: Exp -> Exp -> Exp -> Exp


### PR DESCRIPTION
The slowdown mentioned in the comment doesn't seem to happen anymore. To measure the performance difference, I used `bin/mhs -imhs -isrc -ilib -ipaths MicroHs.Main +RTS -v` and compared the outputs.

<details>
<summary>Before</summary>

```
         508896 combinator file size
         107325 cells at start
       50000000 cells heap size (800000000 bytes)
     2338381568 cells allocated (670.3 Mbyte/s)
             51 GCs
        3081100 max cells used
     5642256383 reductions (101.1 Mred/s)
          56423 yields (0 resched)
            686 array alloc
            685 array free
            682 foreign alloc
            682 foreign free
         856440 bytestring alloc (max 102986)
        8260136 bytestring alloc bytes (max 1578725)
         856440 bytestring free
              1 thread create
              1 thread reap
              0 stableptr alloc
              0 stableptr free
              0 weakptr alloc
              0 weakptr free
          55.81s total expired time
           4.57s gc expired time = 8.2% (4.36s mark + 0.20s scan)
 GC reductions A=2632, K=176, I=74, int=772451, flip=1277, BI=96, BxI=45, C'BxI=7, CC=9, C'I=1, C'BBCP=0
 special reductions B'=0 K4=0 K3=0 K2=0 C'B=0, Z=1, R=0
```
</details>

<details>
<summary>After</summary>

```
         508856 combinator file size
         107315 cells at start
       50000000 cells heap size (800000000 bytes)
     2338315308 cells allocated (669.8 Mbyte/s)
             51 GCs
        3080990 max cells used
     5642092362 reductions (101.0 Mred/s)
          56421 yields (0 resched)
            686 array alloc
            685 array free
            682 foreign alloc
            682 foreign free
         856421 bytestring alloc (max 102938)
        8260013 bytestring alloc bytes (max 1578721)
         856421 bytestring free
              1 thread create
              1 thread reap
              0 stableptr alloc
              0 stableptr free
              0 weakptr alloc
              0 weakptr free
          55.85s total expired time
           4.91s gc expired time = 8.8% (4.69s mark + 0.22s scan)
 GC reductions A=2632, K=176, I=74, int=771815, flip=1277, BI=96, BxI=45, C'BxI=7, CC=9, C'I=1, C'BBCP=0
 special reductions B'=0 K4=0 K3=0 K2=0 C'B=0, Z=1, R=0
```
</details>

In particular, there are a bit less memory allocations and reductions.