### PR TITLE
Add missing `Prelude` exports

### DIFF
--- a/lib/Data/Fractional.hs
+++ b/lib/Data/Fractional.hs
@@ -10,6 +10,8 @@ import Data.Ratio_Type
 import Data.Real
 import {-# SOURCE #-} Data.Typeable
 
+infixl 7 /
+
 class Num a => Fractional a where
   (/) :: a -> a -> a
   recip :: a -> a

--- a/lib/Data/Function.hs
+++ b/lib/Data/Function.hs
@@ -37,6 +37,7 @@ on op sel x y = op (sel x) (sel y)
 asTypeOf :: forall a . a -> a -> a
 asTypeOf = const
 
+infixr 0 `seq`
 seq :: forall a b . a -> b -> b
 seq = primSeq
 

--- a/lib/Prelude.hs
+++ b/lib/Prelude.hs
@@ -82,10 +82,10 @@ import Data.Semigroup(Semigroup((<>)))
 import Data.String(IsString(..), lines, unlines, words, unwords)
 import Data.Tuple(fst, snd, curry, uncurry)
 import Data.Word.Word(Word)
-import System.IO(IO, putChar, putStr, putStrLn, print, getLine, getContents, interact,
+import System.IO(IO, putChar, putStr, putStrLn, print, getChar, getLine, getContents, interact,
                  FilePath, readFile, writeFile, appendFile, readLn, readIO,
                  cprint, cuprint)
-import System.IO.Error(IOError)
+import System.IO.Error(IOError, ioError, userError)
 import Text.Read(ReadS, Read(..), read, reads, readParen, lex)
 import Text.Show(Show(..), ShowS, shows, showChar, showString, showParen)
 import Primitives(_wordSize, _isWindows)


### PR DESCRIPTION
Add missing `Prelude` exports and missing fixity declarations.

With these changes, `Prelude` is almost report compliant. The only thing that's missing is `catch :: IO a -> (IOError -> IO a) -> IO a`, which is called `catchIOError` in MicroHs and GHC (`catch` also exists, but has a more general type). However, GHC doesn't export `catch` (or `catchIOError`) from `Prelude` either, so this is consistent with GHC.