### PR TITLE
Use record syntax for newtypes as in `base`

### DIFF
--- a/lib/Control/WrappedMonad.hs
+++ b/lib/Control/WrappedMonad.hs
@@ -1,14 +1,11 @@
-module Control.WrappedMonad(WrappedMonad(..), unwrapMonad, WrappedArrow(..), unwrapArrow) where
+module Control.WrappedMonad(WrappedMonad(..), WrappedArrow(..)) where
 import qualified Prelude(); import MiniPrelude
 import Control.Applicative
 import Control.Arrow
 import Mhs.Builtin
 
-newtype WrappedMonad m a = WrapMonad (m a)
+newtype WrappedMonad m a = WrapMonad { unwrapMonad :: m a }
   deriving (Monad)
-
-unwrapMonad :: WrappedMonad m a -> m a
-unwrapMonad (WrapMonad ma) = ma
 
 instance Monad m => Functor (WrappedMonad m) where
   fmap f (WrapMonad v) = WrapMonad (fmap f v)
@@ -22,10 +19,7 @@ instance MonadPlus m => Alternative (WrappedMonad m) where
   empty = WrapMonad mzero
   WrapMonad u <|> WrapMonad v = WrapMonad (u `mplus` v)
 
-newtype WrappedArrow a b c = WrapArrow (a b c)
-
-unwrapArrow :: WrappedArrow a b c -> a b c
-unwrapArrow (WrapArrow abc) = abc
+newtype WrappedArrow a b c = WrapArrow { unwrapArrow :: a b c }
 
 instance Arrow a => Functor (WrappedArrow a b) where
   fmap f (WrapArrow a) = WrapArrow (a >>> arr f)

--- a/lib/Data/Foldable/Internal.hs
+++ b/lib/Data/Foldable/Internal.hs
@@ -11,13 +11,9 @@ import Data.List
 import Data.Ord
 import {-# SOURCE #-} Data.Typeable
 
-newtype Max a = Max (Maybe a)
-getMax :: forall a . Max a -> Maybe a
-getMax (Max ma) = ma
+newtype Max a = Max { getMax :: Maybe a }
 
-newtype Min a = Min (Maybe a)
-getMin :: forall a . Min a -> Maybe a
-getMin (Min ma) = ma
+newtype Min a = Min { getMin :: Maybe a }
 
 instance forall a . Ord a => Semigroup (Max a) where
     m <> Max Nothing = m
@@ -41,9 +37,7 @@ instance forall a . Ord a => Monoid (Min a) where
     mempty = Min Nothing
     mconcat = foldl' (<>) mempty
 
-newtype StateL s a = StateL (s -> (s, a))
-runStateL :: StateL s a -> s -> (s, a)
-runStateL (StateL f) = f
+newtype StateL s a = StateL { runStateL :: s -> (s, a) }
 
 instance Functor (StateL s) where
     fmap f (StateL k) = StateL $ \ s -> let (s', v) = k s in (s', f v)
@@ -55,9 +49,7 @@ instance Applicative (StateL s) where
             (s'', v) = kv s'
         in (s'', f v)
 
-newtype StateR s a = StateR (s -> (s, a))
-runStateR :: StateR s a -> s -> (s, a)
-runStateR (StateR f) = f
+newtype StateR s a = StateR { runStateR :: s -> (s, a) }
 
 instance Functor (StateR s) where
     fmap f (StateR k) = StateR $ \ s -> let (s', v) = k s in (s', f v)
@@ -69,9 +61,7 @@ instance Applicative (StateR s) where
             (s'', f) = kf s'
         in (s'', f v)
 
-newtype StateT s m a = StateT (s -> m (s, a))
-runStateT :: StateT s m a -> s -> m (s, a)
-runStateT (StateT f) = f
+newtype StateT s m a = StateT { runStateT :: s -> m (s, a) }
 
 instance Monad m => Functor (StateT s m) where
     fmap = liftM

--- a/lib/Data/Functor/Const_Type.hs
+++ b/lib/Data/Functor/Const_Type.hs
@@ -1,6 +1,6 @@
 -- Copyright 2023 Lennart Augustsson
 -- See LICENSE file for full license.
-module Data.Functor.Const_Type(Const(..), getConst) where
+module Data.Functor.Const_Type(Const(..)) where
 import qualified Prelude()              -- do not import Prelude
 import Primitives
 import Data.Bool
@@ -14,8 +14,5 @@ import {-# SOURCE #-} Data.Typeable
 import Text.Show
 
 type Const :: forall k . Type -> k -> Type
-newtype Const a b = Const a
+newtype Const a b = Const { getConst :: a }
   deriving (Eq, Ord, Show)
-
-getConst :: forall a b . Const a b -> a
-getConst (Const a) = a

--- a/lib/Data/Ord.hs
+++ b/lib/Data/Ord.hs
@@ -6,9 +6,10 @@ import qualified Prelude()              -- do not import Prelude
 import Primitives
 import Data.Bool_Type
 import Data.Bounded
+import Data.Eq
 import Data.Functor
 import Data.Ordering_Type
-import Data.Eq
+import Data.Records
 import {-# SOURCE #-} Data.Typeable
 import Text.Show
 
@@ -46,11 +47,10 @@ comparing f x y = compare (f x) (f y)
 clamp :: (Ord a) => (a, a) -> a -> a
 clamp (low, high) a = min high (max a low)
 
-{-
 newtype Down a = Down
     { getDown :: a -- ^ @since 4.14.0.0
     }
-    deriving
+{-    deriving
       ( Eq        -- ^ @since 4.6.0.0
       , Num       -- ^ @since 4.11.0.0
       , Semigroup -- ^ @since 4.11.0.0
@@ -66,11 +66,6 @@ newtype Down a = Down
       , Storable   -- ^ @since 4.14.0.0
       )
 -}
-
-newtype Down a = Down a
-
-getDown :: Down a -> a
-getDown (Down a) = a
 
 {-  In Data.Orphans
 instance (Read a) => Read (Down a)

--- a/lib/Data/ZipList.hs
+++ b/lib/Data/ZipList.hs
@@ -1,15 +1,12 @@
-module Data.ZipList(ZipList(..), getZipList) where
+module Data.ZipList(ZipList(..)) where
 --import qualified Prelude(); import MiniPrelude
 import Control.Applicative
 import Data.Foldable
 import Data.Traversable
 --import Mhs.Builtin
 
-newtype ZipList a = ZipList [a]
+newtype ZipList a = ZipList { getZipList :: [a] }
   deriving (Eq, Ord, Show, Foldable)
-
-getZipList :: forall a . ZipList a -> [a]
-getZipList (ZipList as) = as
 
 instance Functor ZipList where
   fmap f (ZipList as) = ZipList (map f as)


### PR DESCRIPTION
This came up when trying to compile `indexed-traversable`.