### PR TITLE
Add `tagged` to Hackage CI

### DIFF
--- a/.github/workflows/hackage-ci.yml
+++ b/.github/workflows/hackage-ci.yml
@@ -134,6 +134,18 @@ jobs:
         PATH="$HOME/.mcabal/bin:$PATH"
         mcabal install monad-loops
 
+    # tagged
+    - name: checkout tagged repo
+      uses: actions/checkout@v4
+      with:
+        repository: ekmett/tagged
+        path: tagged
+    - name: compile and install tagged package
+      run: |
+        PATH="$HOME/.mcabal/bin:$PATH"
+        cd tagged
+        mcabal install
+
     # DONE
     - name: cleanup
       run: |


### PR DESCRIPTION
After https://github.com/ekmett/tagged/pull/69, `tagged` compiles with MicroHs. It has a lot of reverse dependencies (both direct and indirect), so this is a good step to get more packages to compile with MicroHs.