### PR TITLE
Update bytestring modules

### DIFF
--- a/lib/Data/ByteString/Internal.hs
+++ b/lib/Data/ByteString/Internal.hs
@@ -15,7 +15,7 @@ import Data.Monoid.Internal
 import Data.Num
 import Data.Ord
 import Data.String
-import Data.Word.Word8(Word8)
+import Data.Word.Word8(Word8, intToWord8, word8ToInt)
 import {-# SOURCE #-} Data.Typeable
 import Foreign.C.Types(CChar)
 import Text.Show
@@ -145,3 +145,9 @@ sameByteString :: ByteString -> ByteString -> Bool
 sameByteString bs1 bs2 =
   let r = primPtrToWord (primForeignPtrToPtr (primBS2FPtr bs1)) == primPtrToWord (primForeignPtrToPtr (primBS2FPtr bs2))
   in  r `seq` bs1 `primSeq` bs2 `primSeq` r
+
+c2w :: Char -> Word8
+c2w = intToWord8 . primOrd
+
+w2c :: Word8 -> Char
+w2c = primChr . word8ToInt

--- a/lib/Data/ByteString/Lazy.hs
+++ b/lib/Data/ByteString/Lazy.hs
@@ -1,23 +1,46 @@
 -- MicroHs does not distinguish lazy and strict bytestrings
 module Data.ByteString.Lazy(module Data.ByteString.Lazy) where
+import Primitives
 import qualified Data.ByteString as B
+import Data.ByteString.Internal(c2w)
 import Data.Coerce
+import qualified Data.List as List
 import Data.List.NonEmpty
+import Data.Int.Int64(Int64)
 import Data.Word.Word8(Word8)
 import Foreign.C.String(CString, CStringLen)
 import System.IO.Base(Handle)
 
+-- XXX: should be a lazy list of strict chunks
 newtype ByteString = BS B.ByteString
   deriving (Eq, Ord)
 
 instance IsString ByteString where
-  fromString = pack
+  fromString = pack . List.map c2w
 
-pack :: String -> ByteString
+empty :: ByteString
+empty = coerce B.empty
+
+singleton :: Word8 -> ByteString
+singleton w = pack [w]
+
+pack :: [Word8] -> ByteString
 pack = coerce B.pack
 
-unpack :: ByteString -> String
+unpack :: ByteString -> [Word8]
 unpack = coerce B.unpack
+
+fromStrict :: B.ByteString -> ByteString
+fromStrict = BS
+
+toStrict :: ByteString -> B.ByteString
+toStrict (BS bs) = bs
+
+fromChunks :: [B.ByteString] -> ByteString
+fromChunks = coerce B.concat
+
+toChunks :: ByteString -> [B.ByteString]
+toChunks (BS bs) = [bs]
 
 fromFilePath :: FilePath -> IO ByteString
 fromFilePath = coerce B.fromFilePath
@@ -30,6 +53,9 @@ cons = coerce B.cons
 
 snoc :: ByteString -> Word8 -> ByteString
 snoc = coerce B.snoc
+
+append :: ByteString -> ByteString -> ByteString
+append = coerce B.append
 
 head :: ByteString -> Word8
 head = coerce B.head
@@ -52,6 +78,9 @@ unsnoc = coerce B.unsnoc
 null :: ByteString -> Bool
 null = coerce B.null
 
+length :: ByteString -> Int64
+length = primIntToInt64 . coerce B.length
+
 map :: (Word8 -> Word8) -> ByteString -> ByteString
 map = coerce B.map
 
@@ -60,6 +89,9 @@ reverse = coerce B.reverse
 
 intersperse :: Word8 -> ByteString -> ByteString
 intersperse = coerce B.intersperse
+
+intercalate :: ByteString -> [ByteString] -> ByteString
+intercalate = coerce B.intercalate
 
 transpose :: [ByteString] -> [ByteString]
 transpose = coerce B.transpose
@@ -106,20 +138,40 @@ maximum = coerce B.maximum
 minimum :: ByteString -> Word8
 minimum = coerce B.minimum
 
+compareLength :: ByteString -> Int64 -> Ordering
+compareLength bs = compare (length bs)
+
 mapAccumL :: (acc -> Word8 -> (acc, Word8)) -> acc -> ByteString -> (acc, ByteString)
 mapAccumL f s x = coerce (B.mapAccumL (coerce f) s (coerce x))
 
 mapAccumR :: (acc -> Word8 -> (acc, Word8)) -> acc -> ByteString -> (acc, ByteString)
 mapAccumR f s x = coerce (B.mapAccumR (coerce f) s (coerce x))
 
+scanl :: (Word8 -> Word8 -> Word8) -> Word8 -> ByteString -> ByteString
+scanl = coerce B.scanl
+
 scanl1 :: (Word8 -> Word8 -> Word8) -> ByteString -> ByteString
 scanl1 = coerce B.scanl1
+
+scanr :: (Word8 -> Word8 -> Word8) -> Word8 -> ByteString -> ByteString
+scanr = coerce B.scanr
 
 scanr1 :: (Word8 -> Word8 -> Word8) -> ByteString -> ByteString
 scanr1 = coerce B.scanr1
 
-replicate :: Int -> Word8 -> ByteString
-replicate = coerce B.replicate
+repeat :: Word8 -> ByteString
+repeat = pack . List.repeat
+
+replicate :: Int64 -> Word8 -> ByteString
+replicate n = coerce (B.replicate (primInt64ToInt n))
+
+cycle :: ByteString -> ByteString
+cycle bs
+  | null bs = error "Data.ByteString.Lazy.cycle: empty bytestring"
+  | otherwise = bs' where bs' = bs `append` bs'
+
+iterate :: (Word8 -> Word8) -> Word8 -> ByteString
+iterate f = pack . List.iterate f
 
 unfoldr :: (a -> Maybe (Word8, a)) -> a -> ByteString
 unfoldr f a = coerce (B.unfoldr (coerce f) a)
@@ -127,20 +179,20 @@ unfoldr f a = coerce (B.unfoldr (coerce f) a)
 unfoldrN :: Int -> (a -> Maybe (Word8, a)) -> a -> (ByteString, Maybe a)
 unfoldrN n f a = coerce (B.unfoldrN n (coerce f) a)
 
-take :: Int -> ByteString -> ByteString
-take = coerce B.take
+take :: Int64 -> ByteString -> ByteString
+take n = coerce B.take (primInt64ToInt n)
 
-takeEnd :: Int -> ByteString -> ByteString
-takeEnd = coerce B.takeEnd
+takeEnd :: Int64 -> ByteString -> ByteString
+takeEnd n = coerce B.takeEnd (primInt64ToInt n)
 
-drop  :: Int -> ByteString -> ByteString
-drop = coerce B.drop
+drop :: Int64 -> ByteString -> ByteString
+drop n = coerce B.drop (primInt64ToInt n)
 
-dropEnd :: Int -> ByteString -> ByteString
-dropEnd = coerce B.dropEnd
+dropEnd :: Int64 -> ByteString -> ByteString
+dropEnd n = coerce B.dropEnd (primInt64ToInt n)
 
-splitAt :: Int -> ByteString -> (ByteString, ByteString)
-splitAt = coerce B.splitAt
+splitAt :: Int64 -> ByteString -> (ByteString, ByteString)
+splitAt n = coerce B.splitAt (primInt64ToInt n)
 
 takeWhile :: (Word8 -> Bool) -> ByteString -> ByteString
 takeWhile = coerce B.takeWhile
@@ -178,38 +230,35 @@ group = coerce B.group
 groupBy :: (Word8 -> Word8 -> Bool) -> ByteString -> [ByteString]
 groupBy = coerce B.groupBy
 
-intercalate :: ByteString -> [ByteString] -> ByteString
-intercalate = coerce B.intercalate
+index :: ByteString -> Int64 -> Word8
+index bs i = B.index (coerce bs) (primInt64ToInt i)
 
-index :: ByteString -> Int -> Word8
-index = coerce B.index
+indexMaybe :: ByteString -> Int64 -> Maybe Word8
+indexMaybe bs i = B.indexMaybe (coerce bs) (primInt64ToInt i)
 
-indexMaybe :: ByteString -> Int -> Maybe Word8
-indexMaybe = coerce B.indexMaybe
+(!?) :: ByteString -> Int64 -> Maybe Word8
+(!?) = indexMaybe
 
-(!?) :: ByteString -> Int -> Maybe Word8
-(!?) = coerce (B.!?)
+elemIndex :: Word8 -> ByteString -> Maybe Int64
+elemIndex w = fmap primIntToInt64 . coerce B.elemIndex w
 
-elemIndex :: Word8 -> ByteString -> Maybe Int
-elemIndex = coerce B.elemIndex
+elemIndexEnd :: Word8 -> ByteString -> Maybe Int64
+elemIndexEnd w = fmap primIntToInt64 . coerce B.elemIndexEnd w
 
-elemIndexEnd :: Word8 -> ByteString -> Maybe Int
-elemIndexEnd = coerce B.elemIndexEnd
+elemIndices :: Word8 -> ByteString -> [Int64]
+elemIndices w = fmap primIntToInt64 . coerce B.elemIndices w
 
-elemIndices :: Word8 -> ByteString -> [Int]
-elemIndices = coerce B.elemIndices
+count :: Word8 -> ByteString -> Int64
+count w = primIntToInt64 . coerce B.count w
 
-count :: Word8 -> ByteString -> Int
-count = coerce B.count
+findIndex :: (Word8 -> Bool) -> ByteString -> Maybe Int64
+findIndex f = fmap primIntToInt64 . coerce B.findIndex f
 
-findIndex :: (Word8 -> Bool) -> ByteString -> Maybe Int
-findIndex = coerce B.findIndex
+findIndexEnd :: (Word8 -> Bool) -> ByteString -> Maybe Int64
+findIndexEnd f = fmap primIntToInt64 . coerce B.findIndexEnd f
 
-findIndexEnd :: (Word8 -> Bool) -> ByteString -> Maybe Int
-findIndexEnd = coerce B.findIndexEnd
-
-findIndices :: (Word8 -> Bool) -> ByteString -> [Int]
-findIndices = coerce B.findIndices
+findIndices :: (Word8 -> Bool) -> ByteString -> [Int64]
+findIndices f = fmap primIntToInt64 . coerce B.findIndices f
 
 elem :: Word8 -> ByteString -> Bool
 elem = coerce B.elem

--- a/lib/Data/ByteString/Lazy/Char8.hs
+++ b/lib/Data/ByteString/Lazy/Char8.hs
@@ -1,334 +1,485 @@
-module Data.ByteString.Lazy.Char8(module Data.ByteString.Lazy.Char8) where
+-- |
+-- Module      : Data.ByteString.Lazy.Char8
+-- Copyright   : (c) Don Stewart 2006-2008
+--               (c) Duncan Coutts 2006-2011
+-- License     : BSD-style
+--
+-- Maintainer  : dons00@gmail.com, duncan@community.haskell.org
+-- Stability   : stable
+-- Portability : portable
+--
+-- Manipulate /lazy/ 'ByteString's using 'Char' operations. All Chars will
+-- be truncated to 8 bits. It can be expected that these functions will
+-- run at identical speeds to their 'Data.Word.Word8' equivalents in
+-- "Data.ByteString.Lazy".
+--
+-- This module is intended to be imported @qualified@, to avoid name
+-- clashes with "Prelude" functions.  eg.
+--
+-- > import qualified Data.ByteString.Lazy.Char8 as C
+--
+-- The Char8 interface to bytestrings provides an instance of IsString
+-- for the ByteString type, enabling you to use string literals, and
+-- have them implicitly packed to ByteStrings.
+-- Use @{-\# LANGUAGE OverloadedStrings \#-}@ to enable this.
+--
+
+module Data.ByteString.Lazy.Char8 (
+
+        -- * The @ByteString@ type
+        ByteString,
+
+        -- * Introducing and eliminating 'ByteString's
+        L.empty,
+        singleton,
+        pack,
+        unpack,
+        L.fromChunks,
+        L.toChunks,
+        L.fromStrict,
+        L.toStrict,
+
+        -- * Basic interface
+        cons,
+        --cons',
+        snoc,
+        L.append,
+        head,
+        uncons,
+        last,
+        L.tail,
+        unsnoc,
+        L.init,
+        L.null,
+        L.length,
+
+        -- * Transforming ByteStrings
+        map,
+        L.reverse,
+        intersperse,
+        L.intercalate,
+        L.transpose,
+
+        -- * Reducing 'ByteString's (folds)
+        foldl,
+        foldl',
+        foldl1,
+        foldl1',
+        foldr,
+        foldr',
+        foldr1,
+        foldr1',
+
+        -- ** Special folds
+        L.concat,
+        concatMap,
+        any,
+        all,
+        maximum,
+        minimum,
+        L.compareLength,
+
+        -- * Building ByteStrings
+        -- ** Scans
+        scanl,
+        scanl1,
+        scanr,
+        scanr1,
+
+        -- ** Accumulating maps
+        mapAccumL,
+        mapAccumR,
+
+        -- ** Infinite ByteStrings
+        repeat,
+        replicate,
+        L.cycle,
+        iterate,
+
+        -- ** Unfolding ByteStrings
+        unfoldr,
+
+        -- * Substrings
+
+        -- ** Breaking strings
+        L.take,
+        L.takeEnd,
+        L.drop,
+        L.dropEnd,
+        L.splitAt,
+        takeWhile,
+        takeWhileEnd,
+        dropWhile,
+        dropWhileEnd,
+        span,
+        spanEnd,
+        break,
+        breakEnd,
+        L.group,
+        groupBy,
+        L.inits,
+        L.tails,
+        L.initsNE,
+        L.tailsNE,
+        L.stripPrefix,
+        L.stripSuffix,
+
+        -- ** Breaking into many substrings
+        split,
+        splitWith,
+
+        -- ** Breaking into lines and words
+        lines,
+        words,
+        unlines,
+        unwords,
+
+        -- * Predicates
+        L.isPrefixOf,
+        L.isSuffixOf,
+
+        -- * Searching ByteStrings
+
+        -- ** Searching by equality
+        elem,
+        notElem,
+
+        -- ** Searching with a predicate
+        find,
+        filter,
+        partition,
+
+        -- * Indexing ByteStrings
+        index,
+        indexMaybe,
+        (!?),
+        elemIndex,
+        elemIndexEnd,
+        elemIndices,
+        findIndex,
+        findIndexEnd,
+        findIndices,
+        count,
+
+        -- * Zipping and unzipping ByteStrings
+        zip,
+        zipWith,
+        packZipWith,
+        unzip,
+
+        -- * Ordered ByteStrings
+--        sort,
+
+        -- * Low level conversions
+        -- ** Copying ByteStrings
+        L.copy,
+
+        -- * Reading from ByteStrings
+        -- | Note that a lazy 'ByteString' may hold an unbounded stream of
+        -- @\'0\'@ digits, in which case the functions below may never return.
+        -- If that's a concern, you can use 'take' to first truncate the input
+        -- to an acceptable length.  Non-termination is also possible when
+        -- reading arbitrary precision numbers via 'readInteger' or
+        -- 'readNatural', if the input is an unbounded stream of arbitrary
+        -- decimal digits.
+        --
+        --readInt,
+        --readInt64,
+        --readInt32,
+        --readInt16,
+        --readInt8,
+
+        --readWord,
+        --readWord64,
+        --readWord32,
+        --readWord16,
+        --readWord8,
+
+        --readInteger,
+        --readNatural,
+
+        -- * I\/O with 'ByteString's
+        -- | ByteString I/O uses binary mode, without any character decoding
+        -- or newline conversion. The fact that it does not respect the Handle
+        -- newline mode is considered a flaw and may be changed in a future version.
+
+        -- ** Standard input and output
+        L.getContents,
+        L.putStr,
+        putStrLn,
+        L.interact,
+
+        -- ** Files
+        L.readFile,
+        L.writeFile,
+        L.appendFile,
+
+        -- ** I\/O with Handles
+        L.hGetContents,
+        L.hGet,
+        L.hGetNonBlocking,
+        L.hPut,
+        L.hPutNonBlocking,
+        L.hPutStr,
+        hPutStrLn,
+
+  ) where
+
+import qualified Prelude ()
+import MiniPrelude as P
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as L
+import qualified Data.ByteString as S (ByteString) -- typename only
 import qualified Data.ByteString as B
-import Data.Coerce
-import Data.List.NonEmpty
-import Data.Word.Word8(Word8)
-import Foreign.C.String(CString, CStringLen)
-import System.IO.Base(Handle)
+import qualified Data.ByteString.Unsafe as B
+import Data.List.NonEmpty (NonEmpty(..))
 
-newtype ByteString = BS B.ByteString
-  deriving (Eq, Ord)
+import Data.ByteString.Internal (c2w, w2c)
 
-instance IsString ByteString where
-  fromString = pack
+import Data.Int (Int64)
+import qualified Data.List as List
 
-pack :: String -> ByteString
-pack = coerce B.pack
+import System.IO.Base (Handle, stdout)
 
-unpack :: ByteString -> String
-unpack = coerce B.unpack
+------------------------------------------------------------------------
 
-fromFilePath :: FilePath -> IO ByteString
-fromFilePath = coerce B.fromFilePath
+singleton :: Char -> ByteString
+singleton = L.singleton . c2w
 
-toFilePath :: ByteString -> IO FilePath
-toFilePath = coerce B.toFilePath
+pack :: [Char] -> ByteString
+pack = L.pack . P.map c2w
+
+unpack :: ByteString -> [Char]
+unpack = P.map w2c . L.unpack
+
+infixr 5 `cons`, `cons'` --same as list (:)
+infixl 5 `snoc`
 
 cons :: Char -> ByteString -> ByteString
-cons = coerce B.cons
+cons = L.cons . c2w
+
+--cons' :: Char -> ByteString -> ByteString
+--cons' = L.cons' . c2w
 
 snoc :: ByteString -> Char -> ByteString
-snoc = coerce B.snoc
+snoc p = L.snoc p . c2w
 
 head :: ByteString -> Char
-head = coerce B.head
-
-tail :: ByteString -> ByteString
-tail = coerce B.tail
+head = w2c . L.head
 
 uncons :: ByteString -> Maybe (Char, ByteString)
-uncons = coerce B.uncons
-
-last :: ByteString -> Char
-last = coerce B.last
-
-init :: ByteString -> ByteString
-init = coerce B.init
+uncons bs = case L.uncons bs of
+                  Nothing -> Nothing
+                  Just (w, bs') -> Just (w2c w, bs')
 
 unsnoc :: ByteString -> Maybe (ByteString, Char)
-unsnoc = coerce B.unsnoc
+unsnoc bs = case L.unsnoc bs of
+                  Nothing -> Nothing
+                  Just (bs', w) -> Just (bs', w2c w)
 
-null :: ByteString -> Bool
-null = coerce B.null
+last :: ByteString -> Char
+last = w2c . L.last
 
 map :: (Char -> Char) -> ByteString -> ByteString
-map = coerce B.map
-
-reverse :: ByteString -> ByteString
-reverse = coerce B.reverse
+map f = L.map (c2w . f . w2c)
 
 intersperse :: Char -> ByteString -> ByteString
-intersperse = coerce B.intersperse
-
-transpose :: [ByteString] -> [ByteString]
-transpose = coerce B.transpose
+intersperse = L.intersperse . c2w
 
 foldl :: (a -> Char -> a) -> a -> ByteString -> a
-foldl f z x = B.foldl (coerce f) z (coerce x)
+foldl f = L.foldl (\a c -> f a (w2c c))
 
 foldl' :: (a -> Char -> a) -> a -> ByteString -> a
-foldl' f z x = B.foldl' (coerce f) z (coerce x)
+foldl' f = L.foldl' (\a c -> f a (w2c c))
 
 foldr :: (Char -> a -> a) -> a -> ByteString -> a
-foldr f z x = B.foldr (coerce f) z (coerce x)
+foldr f = L.foldr (f . w2c)
 
 foldr' :: (Char -> a -> a) -> a -> ByteString -> a
-foldr' f z x = B.foldr' (coerce f) z (coerce x)
+foldr' f = L.foldr' (f . w2c)
 
 foldl1 :: (Char -> Char -> Char) -> ByteString -> Char
-foldl1 = coerce B.foldl1
+foldl1 f ps = w2c (L.foldl1 (\x y -> c2w (f (w2c x) (w2c y))) ps)
 
 foldl1' :: (Char -> Char -> Char) -> ByteString -> Char
-foldl1' = coerce B.foldl1'
+foldl1' f ps = w2c (L.foldl1' (\x y -> c2w (f (w2c x) (w2c y))) ps)
 
 foldr1 :: (Char -> Char -> Char) -> ByteString -> Char
-foldr1 = coerce B.foldr1
+foldr1 f ps = w2c (L.foldr1 (\x y -> c2w (f (w2c x) (w2c y))) ps)
 
 foldr1' :: (Char -> Char -> Char) -> ByteString -> Char
-foldr1' = coerce B.foldr1'
-
-concat :: [ByteString] -> ByteString
-concat = coerce B.concat
+foldr1' f ps = w2c (L.foldr1' (\x y -> c2w (f (w2c x) (w2c y))) ps)
 
 concatMap :: (Char -> ByteString) -> ByteString -> ByteString
-concatMap = coerce B.concatMap
+concatMap f = L.concatMap (f . w2c)
 
 any :: (Char -> Bool) -> ByteString -> Bool
-any = coerce B.any
+any f = L.any (f . w2c)
 
 all :: (Char -> Bool) -> ByteString -> Bool
-all = coerce B.all
+all f = L.all (f . w2c)
 
 maximum :: ByteString -> Char
-maximum = coerce B.maximum
+maximum = w2c . L.maximum
 
 minimum :: ByteString -> Char
-minimum = coerce B.minimum
+minimum = w2c . L.minimum
 
-mapAccumL :: (acc -> Char -> (acc, Char)) -> acc -> ByteString -> (acc, ByteString)
-mapAccumL f s x = coerce (B.mapAccumL (coerce f) s (coerce x))
-
-mapAccumR :: (acc -> Char -> (acc, Char)) -> acc -> ByteString -> (acc, ByteString)
-mapAccumR f s x = coerce (B.mapAccumR (coerce f) s (coerce x))
+scanl :: (Char -> Char -> Char) -> Char -> ByteString -> ByteString
+scanl f z = L.scanl (\a b -> c2w (f (w2c a) (w2c b))) (c2w z)
 
 scanl1 :: (Char -> Char -> Char) -> ByteString -> ByteString
-scanl1 = coerce B.scanl1
+scanl1 f = L.scanl1 f'
+  where f' accumulator value = c2w (f (w2c accumulator) (w2c value))
+
+scanr
+    :: (Char -> Char -> Char)
+    -- ^ element -> accumulator -> new accumulator
+    -> Char
+    -- ^ starting value of accumulator
+    -> ByteString
+    -- ^ input of length n
+    -> ByteString
+    -- ^ output of length n+1
+scanr f = L.scanr f' . c2w
+  where f' accumulator value = c2w (f (w2c accumulator) (w2c value))
 
 scanr1 :: (Char -> Char -> Char) -> ByteString -> ByteString
-scanr1 = coerce B.scanr1
+scanr1 f = L.scanr1 f'
+  where f' accumulator value = c2w (f (w2c accumulator) (w2c value))
 
-replicate :: Int -> Char -> ByteString
-replicate = coerce B.replicate
+mapAccumL :: (acc -> Char -> (acc, Char)) -> acc -> ByteString -> (acc, ByteString)
+mapAccumL f = L.mapAccumL (\a w -> case f a (w2c w) of (a',c) -> (a', c2w c))
+
+mapAccumR :: (acc -> Char -> (acc, Char)) -> acc -> ByteString -> (acc, ByteString)
+mapAccumR f = L.mapAccumR (\acc w -> case f acc (w2c w) of (acc', c) -> (acc', c2w c))
+
+iterate :: (Char -> Char) -> Char -> ByteString
+iterate f = L.iterate (c2w . f . w2c) . c2w
+
+repeat :: Char -> ByteString
+repeat = L.repeat . c2w
+
+replicate :: Int64 -> Char -> ByteString
+replicate w c = L.replicate w (c2w c)
 
 unfoldr :: (a -> Maybe (Char, a)) -> a -> ByteString
-unfoldr f a = coerce (B.unfoldr (coerce f) a)
-
-unfoldrN :: Int -> (a -> Maybe (Char, a)) -> a -> (ByteString, Maybe a)
-unfoldrN n f a = coerce (B.unfoldrN n (coerce f) a)
-
-take :: Int -> ByteString -> ByteString
-take = coerce B.take
-
-takeEnd :: Int -> ByteString -> ByteString
-takeEnd = coerce B.takeEnd
-
-drop  :: Int -> ByteString -> ByteString
-drop = coerce B.drop
-
-dropEnd :: Int -> ByteString -> ByteString
-dropEnd = coerce B.dropEnd
-
-splitAt :: Int -> ByteString -> (ByteString, ByteString)
-splitAt = coerce B.splitAt
+unfoldr f = L.unfoldr $ \a -> case f a of
+                                    Nothing      -> Nothing
+                                    Just (c, a') -> Just (c2w c, a')
 
 takeWhile :: (Char -> Bool) -> ByteString -> ByteString
-takeWhile = coerce B.takeWhile
+takeWhile f = L.takeWhile (f . w2c)
 
 takeWhileEnd :: (Char -> Bool) -> ByteString -> ByteString
-takeWhileEnd = coerce B.takeWhileEnd
+takeWhileEnd f = L.takeWhileEnd (f . w2c)
 
 dropWhile :: (Char -> Bool) -> ByteString -> ByteString
-dropWhile = coerce B.dropWhile
+dropWhile f = L.dropWhile (f . w2c)
 
 dropWhileEnd :: (Char -> Bool) -> ByteString -> ByteString
-dropWhileEnd = coerce B.dropWhileEnd
+dropWhileEnd f = L.dropWhileEnd (f . w2c)
 
 break :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
-break = coerce B.break
+break f = L.break (f . w2c)
 
 breakEnd :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
-breakEnd = coerce B.breakEnd
+breakEnd f = L.breakEnd (f . w2c)
 
 span :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
-span = coerce B.span
+span f = L.span (f . w2c)
 
 spanEnd :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
-spanEnd = coerce B.spanEnd
-
-splitWith :: (Char -> Bool) -> ByteString -> [ByteString]
-splitWith = coerce B.splitWith
+spanEnd f = L.spanEnd (f . w2c)
 
 split :: Char -> ByteString -> [ByteString]
-split = coerce B.split
+split = L.split . c2w
 
-group :: ByteString -> [ByteString]
-group = coerce B.group
+splitWith :: (Char -> Bool) -> ByteString -> [ByteString]
+splitWith f = L.splitWith (f . w2c)
 
 groupBy :: (Char -> Char -> Bool) -> ByteString -> [ByteString]
-groupBy = coerce B.groupBy
+groupBy k = L.groupBy (\a b -> k (w2c a) (w2c b))
 
-intercalate :: ByteString -> [ByteString] -> ByteString
-intercalate = coerce B.intercalate
+index :: ByteString -> Int64 -> Char
+index = (w2c .) . L.index
 
-index :: ByteString -> Int -> Char
-index = coerce B.index
+indexMaybe :: ByteString -> Int64 -> Maybe Char
+indexMaybe = (fmap w2c .) . L.indexMaybe
 
-indexMaybe :: ByteString -> Int -> Maybe Char
-indexMaybe = coerce B.indexMaybe
+(!?) :: ByteString -> Int64 -> Maybe Char
+(!?) = indexMaybe
 
-(!?) :: ByteString -> Int -> Maybe Char
-(!?) = coerce (B.!?)
+elemIndex :: Char -> ByteString -> Maybe Int64
+elemIndex = L.elemIndex . c2w
 
-elemIndex :: Char -> ByteString -> Maybe Int
-elemIndex = coerce B.elemIndex
+elemIndexEnd :: Char -> ByteString -> Maybe Int64
+elemIndexEnd = L.elemIndexEnd . c2w
 
-elemIndexEnd :: Char -> ByteString -> Maybe Int
-elemIndexEnd = coerce B.elemIndexEnd
+elemIndices :: Char -> ByteString -> [Int64]
+elemIndices = L.elemIndices . c2w
 
-elemIndices :: Char -> ByteString -> [Int]
-elemIndices = coerce B.elemIndices
+findIndex :: (Char -> Bool) -> ByteString -> Maybe Int64
+findIndex f = L.findIndex (f . w2c)
 
-count :: Char -> ByteString -> Int
-count = coerce B.count
+findIndexEnd :: (Char -> Bool) -> ByteString -> Maybe Int64
+findIndexEnd f = L.findIndexEnd (f . w2c)
 
-findIndex :: (Char -> Bool) -> ByteString -> Maybe Int
-findIndex = coerce B.findIndex
+findIndices :: (Char -> Bool) -> ByteString -> [Int64]
+findIndices f = L.findIndices (f . w2c)
 
-findIndexEnd :: (Char -> Bool) -> ByteString -> Maybe Int
-findIndexEnd = coerce B.findIndexEnd
-
-findIndices :: (Char -> Bool) -> ByteString -> [Int]
-findIndices = coerce B.findIndices
+count :: Char -> ByteString -> Int64
+count c = L.count (c2w c)
 
 elem :: Char -> ByteString -> Bool
-elem = coerce B.elem
+elem c = L.elem (c2w c)
 
 notElem :: Char -> ByteString -> Bool
-notElem = coerce B.notElem
+notElem c = L.notElem (c2w c)
 
 filter :: (Char -> Bool) -> ByteString -> ByteString
-filter = coerce B.filter
-
-find :: (Char -> Bool) -> ByteString -> Maybe Char
-find = coerce B.find
+filter f = L.filter (f . w2c)
 
 partition :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
-partition = coerce B.partition
+partition f = L.partition (f . w2c)
 
-isPrefixOf :: ByteString -> ByteString -> Bool
-isPrefixOf = coerce B.isPrefixOf
-
-stripPrefix :: ByteString -> ByteString -> Maybe ByteString
-stripPrefix = coerce B.stripPrefix
-
-isSuffixOf :: ByteString -> ByteString -> Bool
-isSuffixOf = coerce B.isSuffixOf
-
-stripSuffix :: ByteString -> ByteString -> Maybe ByteString
-stripSuffix = coerce B.stripSuffix
-
-isInfixOf :: ByteString -> ByteString -> Bool
-isInfixOf = coerce B.isInfixOf
-
-isValidUtf8 :: ByteString -> Bool
-isValidUtf8 = coerce B.isValidUtf8
-
-breakSubstring :: ByteString -> ByteString -> (ByteString,ByteString)
-breakSubstring = coerce B.breakSubstring
+find :: (Char -> Bool) -> ByteString -> Maybe Char
+find f ps = w2c `fmap` L.find (f . w2c) ps
 
 zip :: ByteString -> ByteString -> [(Char,Char)]
-zip = coerce B.zip
+zip ps qs
+    | L.null ps || L.null qs = []
+    | otherwise = (head ps, head qs) : zip (L.tail ps) (L.tail qs)
 
 zipWith :: (Char -> Char -> a) -> ByteString -> ByteString -> [a]
-zipWith f x y = B.zipWith (coerce f) (coerce x) (coerce y)
+zipWith f = L.zipWith ((. w2c) . f . w2c)
 
 packZipWith :: (Char -> Char -> Char) -> ByteString -> ByteString -> ByteString
-packZipWith = coerce B.packZipWith
+packZipWith f = L.packZipWith f'
+    where
+        f' c1 c2 = c2w $ f (w2c c1) (w2c c2)
 
-unzip :: [(Char,Char)] -> (ByteString,ByteString)
-unzip = coerce B.unzip
+unzip :: [(Char, Char)] -> (ByteString, ByteString)
+unzip ls = (pack (fmap fst ls), pack (fmap snd ls))
 
-inits :: ByteString -> [ByteString]
-inits = coerce B.inits
+lines :: ByteString -> [ByteString]
+lines bs
+  | L.null bs = []
+  | otherwise = case elemIndex '\n' bs of
+      Nothing -> [bs]
+      Just n  -> L.take n bs : lines (L.drop (n + 1) bs)
 
-initsNE :: ByteString -> NonEmpty ByteString
-initsNE = coerce B.initsNE
+unlines :: [ByteString] -> ByteString
+unlines = List.foldr (\x t -> x `L.append` cons '\n' t) L.empty
 
-tails :: ByteString -> [ByteString]
-tails = coerce B.tails
+words :: ByteString -> [ByteString]
+words = List.filter (not . L.null) . splitWith isSpace
 
-tailsNE :: ByteString -> NonEmpty ByteString
-tailsNE = coerce B.tailsNE
+unwords :: [ByteString] -> ByteString
+unwords = L.intercalate (singleton ' ')
 
-sort :: ByteString -> ByteString
-sort = coerce B.sort
+hPutStrLn :: Handle -> ByteString -> IO ()
+hPutStrLn h ps = L.hPut h ps >> L.hPut h (L.singleton 0x0a)
 
-useAsCString :: ByteString -> (CString -> IO a) -> IO a
-useAsCString x = B.useAsCString (coerce x)
-
-useAsCStringLen :: ByteString -> (CStringLen -> IO a) -> IO a
-useAsCStringLen x = B.useAsCStringLen (coerce x)
-
-packCString :: CString -> IO ByteString
-packCString = coerce B.packCString
-
-packCStringLen :: CStringLen -> IO ByteString
-packCStringLen = coerce B.packCStringLen
-
-copy :: ByteString -> ByteString
-copy = coerce B.copy
-
-getLine :: IO ByteString
-getLine = coerce B.getLine
-
-hGetLine :: Handle -> IO ByteString
-hGetLine = coerce B.hGetLine
-
-hPut :: Handle -> ByteString -> IO ()
-hPut = coerce B.hPut
-
-hPutNonBlocking :: Handle -> ByteString -> IO ByteString
-hPutNonBlocking = coerce B.hPutNonBlocking
-
-hPutStr :: Handle -> ByteString -> IO ()
-hPutStr = coerce B.hPutStr
-
-putStr :: ByteString -> IO ()
-putStr = coerce B.putStr
-
-hGet :: Handle -> Int -> IO ByteString
-hGet = coerce B.hGet
-
-hGetNonBlocking :: Handle -> Int -> IO ByteString
-hGetNonBlocking = coerce B.hGetNonBlocking
-
-hGetSome :: Handle -> Int -> IO ByteString
-hGetSome = coerce B.hGetSome
-
-hGetContents :: Handle -> IO ByteString
-hGetContents = coerce B.hGetContents
-
-getContents :: IO ByteString
-getContents = coerce B.getContents
-
-interact :: (ByteString -> ByteString) -> IO ()
-interact = coerce B.interact
-
-readFile :: FilePath -> IO ByteString
-readFile = coerce B.readFile
-
-writeFile :: FilePath -> ByteString -> IO ()
-writeFile = coerce B.writeFile
-
-appendFile :: FilePath -> ByteString -> IO ()
-appendFile = coerce B.appendFile
+putStrLn :: ByteString -> IO ()
+putStrLn = hPutStrLn stdout

--- a/lib/Data/Text/Encoding.hs
+++ b/lib/Data/Text/Encoding.hs
@@ -22,14 +22,8 @@ import Data.ByteString (ByteString, isValidUtf8)
 import Data.ByteString qualified as BS
 import Data.Char
 import Data.Text
-import Data.Word.Word8(Word8)
+import Data.Word.Word8 (intToWord8, word8ToInt)
 import Unsafe.Coerce (unsafeCoerce)
-
-intToWord8 :: Int -> Word8
-intToWord8 i = unsafeCoerce (i .&. 0xFF) -- Safety: Int and Word8 have the same representation and `i .&. 0xFF` ensures that the value is in the Word8 range
-
-word8ToInt :: Word8 -> Int
-word8ToInt w = unsafeCoerce w -- Safety: Int and Word8 have the same representation and a Word8 is in the Int range
 
 isValidASCII :: ByteString -> Bool
 isValidASCII = BS.all (< 0x80)

--- a/lib/Data/Word/Word8.hs
+++ b/lib/Data/Word/Word8.hs
@@ -1,6 +1,6 @@
 -- Copyright 2023,2024 Lennart Augustsson
 -- See LICENSE file for full license.
-module Data.Word.Word8(Word8, bitReverse8) where
+module Data.Word.Word8(Word8, bitReverse8, intToWord8, word8ToInt) where
 import qualified Prelude()              -- do not import Prelude
 import Primitives
 import Control.Error
@@ -119,3 +119,9 @@ bitReverse8 x0 = x3
         x1 = ((x0 .&. 0x55) <<<  1) .|. ((x0 .&. 0xAA) >>>  1)
         x2 = ((x1 .&. 0x33) <<<  2) .|. ((x1 .&. 0xCC) >>>  2)
         x3 = ((x2 .&. 0x0F) <<<  4) .|. ((x2 .&. 0xF0) >>>  4)
+
+intToWord8 :: Int -> Word8
+intToWord8 i = primUnsafeCoerce (i .&. 0xFF) -- Safety: Int and Word8 have the same representation and `i .&. 0xFF` ensures that the value is in the Word8 range
+
+word8ToInt :: Word8 -> Int
+word8ToInt w = primUnsafeCoerce w -- Safety: Int and Word8 have the same representation and a Word8 is in the Int range


### PR DESCRIPTION
The `Char8` modules defined their own `ByteString` type, but in `bytestring`, they use the existing one. I added most functions from `bytestring`, mostly using the original implementations. I also added some functions that were needed to `Data.ByteString.Lazy`. The `intToWord8` & `word8ToInt` helpers were moved to `Data.Word.Word8`, so that they can be used for defining `c2w` & `w2c` in `Data.ByteString.Internal`.