### PR TITLE
process the constraints and do not skolemize type variables in nested forall

### DIFF
--- a/src/MicroHs/TypeCheck.hs
+++ b/src/MicroHs/TypeCheck.hs
@@ -2289,7 +2289,12 @@ unArrow loc (EForall _ iks t) = do
   -- Found forall in a co-variant position.
   -- Make new unique tyvars in case of clashes.
   -- XXX Is this correct?
-  (_, t') <- shallowSkolemise iks t
+  t' <- tInstForall iks t
+  unArrow loc t'
+-- handle =>
+unArrow loc t | Just (ctx, t') <- getImplies t = do
+  d <- newDictIdent loc
+  addConstraint d ctx
   unArrow loc t'
 unArrow loc t = do
   case getArrow t of


### PR DESCRIPTION
addressing issue #208

Since there seems to be some pressure to fix #208 (see also #315) I started digging into it and I think I now have an idea of what is going on.

```` haskell
incu :: forall a . Num a => a -> (forall b. (Num b, Integral b) => b -> a)
incu x = (+) x . fromIntegral

main = print (incu 1 41)
````

This code would produce unsolved equality constraints. As far as I can understand when `incu` pattern matching is type-checked against its type signature, the forall part will eventually be processed by `unArrow` (via `tcExprR -> tcEqn -> tcPats`) in order to check each pattern type.

In `unArrow` the type part of the `Eforall _ _ t` will go through:

```` haskell
-- XXX Is this correct?
  (_, t') <- shallowSkolemise iks t
  unArrow loc t'
````

I think it is not correct: shallowSkolemise will generate skolems, which cannot be unified. That will create constraints that cannot be satisfied. Instead, if I understand it correctly, the correct thing to do is:

```` haskell
  t' <- tInstForall iks t
````

Now, I think this should be done *before* calling unArrow, as you will see, because everytime unArrow will be called for inner foralls, those parts will be re-instantiated and unification with the outer forall will be impossible.

So, my sort of fix, which works with the above example, doesn't work for those:

```` haskell
incu' :: forall a . (Num a, Show a) => a -> forall b. (Num b, Integral b) => b -> forall c . Show c => (a -> c) -> String
incu' x y f =
  let n = x + fromIntegral y
  in show $ f n

incu'' :: forall a . (Num a, Show a, Integral a) => a -> forall b. (Num b, Integral b) => b -> forall c . Show c => (b -> c) -> String
incu'' x y f =
  let n = x + fromIntegral y
  in show $ f (fromIntegral n)
````

(sorry for this stupid code but I was in a hurry to find something to test which works with ghc)

Even if I do not have a fix (I still have to figure out when tInstForall should be called), I thought it could be useful to share what I've done so far. Maybe some suggestions may come.

ps: the commit adds also the code for dealing with `=>`
