### PR TITLE
concatenate -optl flags with those stored in the package

### DIFF
--- a/src/MicroHs/Main.hs
+++ b/src/MicroHs/Main.hs
@@ -393,6 +393,7 @@ mainCompileC flags pkgs infile = do
                        defs,
                        cpps] ++
                        cArgs flags ++
+                       lArgs flags ++
                        optls ++
                        map (++ "/*.c") cDirs' ++
                       [ rtdir </> "main.c" | not (noLink flags) ] ++


### PR DESCRIPTION
Sorry but I forgot to concatenate the linker flags passed by the packages to those of the command line.