### PR TITLE
Add instance of `Enum` for `IOMode`

### DIFF
--- a/lib/System/IO/Internal.hs
+++ b/lib/System/IO/Internal.hs
@@ -16,6 +16,7 @@ import Control.Monad
 import Control.Monad.Fail
 import Data.Bool
 import Data.Char
+import Data.Enum
 import Data.Eq
 import Data.Function
 import Data.IORef
@@ -43,7 +44,7 @@ instance Show Handle where
 type FilePath = String
 
 data IOMode = ReadMode | WriteMode | AppendMode | ReadWriteMode
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Enum)
 
 ioModeToHMode :: IOMode -> HandleState
 ioModeToHMode ReadMode = HRead


### PR DESCRIPTION
This is in `ghc` but not in `mhs` and it caused me to have to write extra code in QuickCheck (boo!)