### PR TITLE
Add a reusable GitHub Action that installs MicroHs

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,9 +519,42 @@ Contributions are very welcome!
 When modifying the compiler, run `make newmhs` or `make newmhsz` (the latter compresses the binary)
 to generate a compiler that includes your changes.
 
-## Libraries
+## Third-party packages
 
-The libraries live in the `lib/` directory. Adding missing functions/instances/types from the report is a welcome contribution.
+Adding MicroHs support to a third-party package may take some initial effort, either by modifying the package itself, or by extending MicroHs.
+
+- For conditional compilation you can test for `__MHS__` via CPP.
+
+Once a package compiles with MicroHs, make sure it stays that way by adding a GitHub Action to the project repository:
+
+```yaml
+# file .github/workflows/mhs.yml
+
+name: MicroHs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install MicroHs
+        uses: augustss/MicroHs@nightly
+
+      - name: Clone project repository
+        uses: actions/checkout@v4
+
+      - name: Build project
+        run: mcabal -r build
+```
+
+## Bundled libraries
+
+The bundled libraries live in the `lib/` directory. Adding missing functions/instances/types from the report is a welcome contribution.
 Common things from `base` and GHC boot libraries that use a lot of GHC-specific code (such as `array`, `bytestring`, `text`, ...) can also be added.
 
 ## Tests
@@ -606,6 +639,6 @@ gay@disroot.org
   * Q: Why are the error messages so bad?
   * A: Error messages are boring.
 *
-  * Q: Why is the so much source code?
+  * Q: Why is there so much source code?
   * A: I wonder this myself.  10000+ lines of Haskell seems excessive.
        6000+ lines of C is also more than I'd like for such a simple system.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,15 @@
+name: Setup MicroHs
+description: Install `mhs`, `mcabal`, `cpphs`, and basic libraries to `$HOME/.mcabal`
+
+branding:
+  icon: cpu
+  color: white
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      name: Install MicroHs
+      run: |
+        curl -sSL https://github.com/sol/MicroHs/releases/download/nightly/MicroHs-linux-x86_64.tar.gz | tar -xz -C "$HOME"
+        echo "$HOME/.mcabal/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
This PR provides a GitHub Action to install a "nightly" build of MicroHs for CI use by third-party packages.

- This reduce e.g. the [QuickCheck MicroHs CI](https://github.com/nick8325/quickcheck/pull/454)  time by -2 minutes.
- It also lowers the barrier to add MicroHs CI jobs to more projects.
- Right now this still uses binaries from my fork, this is why it is a draft PR for now.  I have a separate PR in the pipeline to remedy this.

I also added instructions to the README on how to set up CI for a third-party package.  I don't care about the exact wording so please feel free to change things as you see fit.