### PR TITLE
Add `atomicWriteIORef`

### DIFF
--- a/lib/Data/IORef.hs
+++ b/lib/Data/IORef.hs
@@ -7,6 +7,7 @@ module Data.IORef(
   modifyIORef',
   atomicModifyIORef,
   atomicModifyIORef',
+  atomicWriteIORef,
   mkWeakIORef,
   ) where
 import qualified Prelude()              -- do not import Prelude
@@ -49,3 +50,5 @@ atomicModifyIORef r f = readIORef r `primBind` \ a -> let (a', b) = f a in write
 atomicModifyIORef' :: forall a b . IORef a -> (a -> (a, b)) -> IO b
 atomicModifyIORef' r f = readIORef r `primBind` \ a -> let (a', b) = f a in primSeq a' (writeIORef r a') `primThen` primSeq b (primReturn b)
 
+atomicWriteIORef :: forall a . IORef a -> a -> IO ()
+atomicWriteIORef = writeIORef


### PR DESCRIPTION
As long as we only use one OS thread we don't need to worry about memory visibility issues.  All operations appear intrinsically "atomic".  As a consequence, this can simply be an alias for `writeIORef`.