### PR TITLE
Add `Data.ByteString.Builder`

### DIFF
--- a/lib/AllOfLib.hs
+++ b/lib/AllOfLib.hs
@@ -28,6 +28,7 @@ import Data.Bifunctor
 import Data.Bitraversable
 import Data.Bounded
 import Data.ByteString
+import Data.ByteString.Builder
 import Data.ByteString.Char8
 import Data.ByteString.Lazy
 import Data.ByteString.Lazy.Char8

--- a/lib/Data/ByteString/Builder.hs
+++ b/lib/Data/ByteString/Builder.hs
@@ -1,0 +1,178 @@
+module Data.ByteString.Builder
+    ( Builder
+    , toLazyByteString
+    , hPutBuilder
+    , writeFile
+
+    , byteString
+    , lazyByteString
+    , shortByteString
+    , int8
+    , word8
+
+    , int16BE
+    , int32BE
+    , int64BE
+
+    , word16BE
+    , word32BE
+    , word64BE
+
+    , floatBE
+    , doubleBE
+
+    , int16LE
+    , int32LE
+    , int64LE
+
+    , word16LE
+    , word32LE
+    , word64LE
+
+    , floatLE
+    , doubleLE
+
+    , char7
+    , string7
+
+    , char8
+    , string8
+
+    , charUtf8
+    , stringUtf8
+
+    , module Data.ByteString.Builder.ASCII
+    , module Data.ByteString.Builder.RealFloat
+    ) where
+
+import qualified Prelude ()
+import MiniPrelude
+
+import Data.Bits
+import Data.ByteString.Builder.Internal
+import Data.ByteString.Lazy as L
+import Data.ByteString.Short.Internal (ShortByteString, fromShort)
+import Data.Char (ord)
+import qualified Data.List as List
+import Data.Int
+import Data.Word
+import Data.Word.Word8 (intToWord8)
+import Numeric.Show (showHex)
+import Primitives
+import System.IO.Internal
+import Unsafe.Coerce (unsafeCoerce)
+
+import Data.ByteString.Builder.ASCII
+import Data.ByteString.Builder.RealFloat
+
+hPutBuilder :: Handle -> Builder -> IO ()
+hPutBuilder h = hPut h . toLazyByteString
+
+writeFile :: FilePath -> Builder -> IO ()
+writeFile f = L.writeFile f . toLazyByteString
+
+shortByteString :: ShortByteString -> Builder
+shortByteString = byteString . fromShort
+
+int8 :: Int8 -> Builder
+int8 = word8 . fromIntegral
+
+word8 :: Word8 -> Builder
+word8 w = lazyByteString $ pack [w]
+
+int16BE :: Int16 -> Builder
+int16BE = word16BE . fromIntegral
+
+int32BE :: Int32 -> Builder
+int32BE = word32BE . fromIntegral
+
+int64BE :: Int64 -> Builder
+int64BE = word64BE . fromIntegral
+
+word16BE :: Word16 -> Builder
+word16BE w = lazyByteString $ pack
+    [ fromIntegral ((w `shiftR` 8) .&. 0xff)
+    , fromIntegral (w .&. 0xff)
+    ]
+
+word32BE :: Word32 -> Builder
+word32BE w = lazyByteString $ pack
+    [ fromIntegral ((w `shiftR` 24) .&. 0xff)
+    , fromIntegral ((w `shiftR` 16) .&. 0xff)
+    , fromIntegral ((w `shiftR` 8) .&. 0xff)
+    , fromIntegral (w .&. 0xff)
+    ]
+
+word64BE :: Word64 -> Builder
+word64BE w = lazyByteString $ pack
+    [ fromIntegral ((w `shiftR` 56) .&. 0xff)
+    , fromIntegral ((w `shiftR` 48) .&. 0xff)
+    , fromIntegral ((w `shiftR` 40) .&. 0xff)
+    , fromIntegral ((w `shiftR` 32) .&. 0xff)
+    , fromIntegral ((w `shiftR` 24) .&. 0xff)
+    , fromIntegral ((w `shiftR` 16) .&. 0xff)
+    , fromIntegral ((w `shiftR` 8) .&. 0xff)
+    , fromIntegral (w .&. 0xff)
+    ]
+
+floatBE :: Float -> Builder
+floatBE = word32BE . unsafeCoerce . primWordFromFloatRaw
+
+doubleBE :: Double -> Builder
+doubleBE = word64BE . primWord64FromDoubleRaw
+
+int16LE :: Int16 -> Builder
+int16LE = word16LE . fromIntegral
+
+int32LE :: Int32 -> Builder
+int32LE = word32LE . fromIntegral
+
+int64LE :: Int64 -> Builder
+int64LE = word64LE . fromIntegral
+
+word16LE :: Word16 -> Builder
+word16LE w = lazyByteString $ pack
+    [ fromIntegral (w .&. 0xff)
+    , fromIntegral ((w `shiftR` 8) .&. 0xff)
+    ]
+
+word32LE :: Word32 -> Builder
+word32LE w = lazyByteString $ pack
+    [ fromIntegral (w .&. 0xff)
+    , fromIntegral ((w `shiftR` 8) .&. 0xff)
+    , fromIntegral ((w `shiftR` 16) .&. 0xff)
+    , fromIntegral ((w `shiftR` 24) .&. 0xff)
+    ]
+
+word64LE :: Word64 -> Builder
+word64LE w = lazyByteString $ pack
+    [ fromIntegral (w .&. 0xff)
+    , fromIntegral ((w `shiftR` 8) .&. 0xff)
+    , fromIntegral ((w `shiftR` 16) .&. 0xff)
+    , fromIntegral ((w `shiftR` 24) .&. 0xff)
+    , fromIntegral ((w `shiftR` 32) .&. 0xff)
+    , fromIntegral ((w `shiftR` 40) .&. 0xff)
+    , fromIntegral ((w `shiftR` 48) .&. 0xff)
+    , fromIntegral ((w `shiftR` 56) .&. 0xff)
+    ]
+
+floatLE :: Float -> Builder
+floatLE = word32LE . unsafeCoerce . primWordFromFloatRaw
+
+doubleLE :: Double -> Builder
+doubleLE = word64LE . primWord64FromDoubleRaw
+
+char7 :: Char -> Builder
+char7 c = word8 (intToWord8 (ord c .&. 0x7f))
+
+string7 :: String -> Builder
+string7 = lazyByteString . pack . List.map (\c -> intToWord8 (ord c .&. 0x7f))
+
+char8 :: Char -> Builder
+char8 c = word8 (intToWord8 (ord c .&. 0xff))
+
+string8 :: String -> Builder
+string8 = lazyByteString . pack . List.map (\c -> intToWord8 (ord c .&. 0xff))
+
+charUtf8 :: Char -> Builder
+charUtf8 c = stringUtf8 [c]

--- a/lib/Data/ByteString/Builder/ASCII.hs
+++ b/lib/Data/ByteString/Builder/ASCII.hs
@@ -1,0 +1,136 @@
+module Data.ByteString.Builder.ASCII where
+
+import qualified Prelude ()
+import MiniPrelude
+
+import Data.Bits
+import Data.ByteString.Builder.Internal
+import Data.ByteString.Internal (StrictByteString)
+import qualified Data.ByteString.Internal as S
+import Data.ByteString.Lazy.Internal (LazyByteString, packChars, unpackBytes)
+import Data.Char
+import Data.Int
+import Data.Integer
+import Data.Word
+import Data.Word.Word8 (word8ToInt)
+import Numeric.Show (showHex)
+import Primitives
+import Unsafe.Coerce (unsafeCoerce)
+
+int8Dec :: Int8 -> Builder
+int8Dec = stringUtf8 . show
+
+int16Dec :: Int16 -> Builder
+int16Dec = stringUtf8 . show
+
+int32Dec :: Int32 -> Builder
+int32Dec = stringUtf8 . show
+
+int64Dec :: Int64 -> Builder
+int64Dec = stringUtf8 . show
+
+intDec :: Int -> Builder
+intDec = stringUtf8 . show
+
+integerDec :: Integer -> Builder
+integerDec = stringUtf8 . show
+
+word8Dec :: Word8 -> Builder
+word8Dec = stringUtf8 . show
+
+word16Dec :: Word16 -> Builder
+word16Dec = stringUtf8 . show
+
+word32Dec :: Word32 -> Builder
+word32Dec = stringUtf8 . show
+
+word64Dec :: Word64 -> Builder
+word64Dec = stringUtf8 . show
+
+wordDec :: Word -> Builder
+wordDec = stringUtf8 . show
+
+word8Hex :: Word8 -> Builder
+word8Hex w = stringUtf8 (showHex w "")
+
+word16Hex :: Word16 -> Builder
+word16Hex w = stringUtf8 (showHex w "")
+
+word32Hex :: Word32 -> Builder
+word32Hex w = stringUtf8 (showHex w "")
+
+word64Hex :: Word64 -> Builder
+word64Hex w = stringUtf8 (showHex w "")
+
+wordHex :: Word -> Builder
+wordHex w = stringUtf8 (showHex w "")
+
+int8HexFixed :: Int8 -> Builder
+int8HexFixed = word8HexFixed . fromIntegral
+
+int16HexFixed :: Int16 -> Builder
+int16HexFixed = word16HexFixed . fromIntegral
+
+int32HexFixed :: Int32 -> Builder
+int32HexFixed = word32HexFixed . fromIntegral
+
+int64HexFixed :: Int64 -> Builder
+int64HexFixed = word64HexFixed . fromIntegral
+
+word8HexFixed :: Word8 -> Builder
+word8HexFixed w = stringUtf8
+    [ intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 4) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce (w .&. 0xf)
+    ]
+
+word16HexFixed :: Word16 -> Builder
+word16HexFixed w = stringUtf8
+    [ intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 12) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 8) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 4) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce (w .&. 0xf)
+    ]
+
+word32HexFixed :: Word32 -> Builder
+word32HexFixed w = stringUtf8
+    [ intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 28) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 24) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 20) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 16) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 12) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 8) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce ((w `shiftR` 4) .&. 0xf)
+    , intToDigit . primWordToInt $ unsafeCoerce (w .&. 0xf)
+    ]
+
+word64HexFixed :: Word64 -> Builder
+word64HexFixed w = stringUtf8
+    [ intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 60) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 56) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 52) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 48) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 44) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 40) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 36) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 32) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 28) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 24) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 20) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 16) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 12) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 8) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord ((w `shiftR` 4) .&. 0xf)
+    , intToDigit . primWordToInt $ primWord64ToWord (w .&. 0xf)
+    ]
+
+floatHexFixed :: Float -> Builder
+floatHexFixed = word32HexFixed . unsafeCoerce . primWordFromFloatRaw
+
+doubleHexFixed :: Double -> Builder
+doubleHexFixed = word64HexFixed . primWord64FromDoubleRaw
+
+byteStringHex :: StrictByteString -> Builder
+byteStringHex = stringUtf8 . concatMap (\w -> [intToDigit $ word8ToInt ((w `shiftR` 4) .&. 0xf), intToDigit $ word8ToInt (w .&. 0xf)]) . S.unpack
+
+lazyByteStringHex :: LazyByteString -> Builder
+lazyByteStringHex = stringUtf8 . concatMap (\w -> [intToDigit $ word8ToInt ((w `shiftR` 4) .&. 0xf), intToDigit $ word8ToInt (w .&. 0xf)]) . unpackBytes

--- a/lib/Data/ByteString/Builder/Internal.hs
+++ b/lib/Data/ByteString/Builder/Internal.hs
@@ -1,0 +1,33 @@
+module Data.ByteString.Builder.Internal where
+
+import qualified Prelude ()
+import MiniPrelude
+
+import Data.ByteString.Internal (StrictByteString)
+import Data.ByteString.Lazy (LazyByteString, append, empty, fromStrict)
+
+newtype Builder = Builder (LazyByteString -> LazyByteString)
+
+instance Semigroup Builder where
+    Builder f <> Builder g = Builder (f . g)
+
+instance Monoid Builder where
+    mempty = Builder id
+
+instance IsString Builder where
+    fromString = stringUtf8
+
+instance Show Builder where
+    show = show . toLazyByteString
+
+toLazyByteString :: Builder -> LazyByteString
+toLazyByteString (Builder f) = f empty
+
+byteString :: StrictByteString -> Builder
+byteString bs = Builder (fromStrict bs `append`)
+
+lazyByteString :: LazyByteString -> Builder
+lazyByteString bs = Builder (bs `append`)
+
+stringUtf8 :: String -> Builder
+stringUtf8 = byteString . _primitive "toUTF8"

--- a/lib/Data/ByteString/Builder/RealFloat.hs
+++ b/lib/Data/ByteString/Builder/RealFloat.hs
@@ -1,0 +1,49 @@
+module Data.ByteString.Builder.RealFloat where
+
+import qualified Prelude ()
+import MiniPrelude
+
+import Data.ByteString.Builder.Internal
+import Data.Double
+import Data.Float
+import Numeric.FormatFloat
+
+floatDec :: Float -> Builder
+floatDec = formatFloat generic
+
+doubleDec :: Double -> Builder
+doubleDec = formatDouble generic
+
+formatFloat :: FloatFormat -> Float -> Builder
+formatFloat (MkFloatFormat fmt prec) f =
+  stringUtf8 $ case fmt of
+    FScientific -> showEFloat prec f ""
+    FStandard -> showFFloat prec f ""
+    FGeneric -> showGFloat prec f ""
+
+formatDouble :: FloatFormat -> Double -> Builder
+formatDouble (MkFloatFormat fmt prec) d =
+  stringUtf8 $ case fmt of
+    FScientific -> showEFloat prec d ""
+    FStandard -> showFFloat prec d ""
+    FGeneric -> showGFloat prec d ""
+
+data FloatFormat = MkFloatFormat FormatMode (Maybe Int)
+
+standard :: Int -> FloatFormat
+standard n = MkFloatFormat FStandard (Just n)
+
+standardDefaultPrecision :: FloatFormat
+standardDefaultPrecision = MkFloatFormat FStandard Nothing
+
+scientific :: FloatFormat
+scientific = MkFloatFormat FScientific Nothing
+
+generic :: FloatFormat
+generic = MkFloatFormat FGeneric Nothing
+
+data FormatMode
+  = FScientific     -- ^ scientific notation
+  | FStandard       -- ^ standard notation with `Maybe Int` digits after the decimal
+  | FGeneric        -- ^ dispatches to scientific or standard notation based on the exponent
+  deriving Show

--- a/lib/base.cabal
+++ b/lib/base.cabal
@@ -58,6 +58,8 @@ library base
         Data.Bool
         Data.Bounded
         Data.ByteString
+        Data.ByteString.Builder
+        Data.ByteString.Builder.RealFloat
         Data.ByteString.Char8
         Data.ByteString.Lazy
         Data.ByteString.Lazy.Char8
@@ -219,6 +221,8 @@ library base
         Control.Monad.ST_Type
         Data.Bits.Base
         Data.Bool_Type
+        Data.ByteString.Builder.ASCII
+        Data.ByteString.Builder.Internal
         Data.ByteString.Internal
         Data.ByteString.Lazy.Internal
         Data.Char_Type


### PR DESCRIPTION
Add `Data.ByteString.Builder` and related modules. The implementation is much simpler than the one from `bytestring` (and probably also much slower), it is essentially a difference list with lazy bytestrings. It also doesn't make sure that the chunks are large, e.g. if you concatenate a bunch of single byte chunks, the resulting lazy bytestring will consist of these single byte chunks.