### PR TITLE
Remove `ghc-prim` dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ NODE=node
 #NODEFLAGS=--stack_size=8192
 #
 MHSINCNP= -i $(MHSGMP) -imhs -isrc -ilib
-MHSINC=$(MHSINCNP) -ipaths 
+MHSINC=$(MHSINCNP) -ipaths
 MAINMODULE=MicroHs.Main
 #
 .PHONY:	clean bootstrap install ghcgen newmhs newmhsz cachelib timecompile exampletest cachetest runtest runtestmhs everytest everytestmhs nfibtest info install minstall installmsg
@@ -138,7 +138,7 @@ mhs.js:	src/*/*.hs $(RTS)/*.h $(RTS)/*/*.h targets.conf
 bootstrap:	bin/mhs-stage2
 	@echo "*** copy stage2 to bin/mhs"
 	cp bin/mhs-stage2 bin/mhs
-	cp generated/mhs-stage2.c generated/mhs.c 
+	cp generated/mhs-stage2.c generated/mhs.c
 
 # Build stage1 compiler with existing compiler
 bin/mhs-stage1:	bin/mhs src/*/*.hs
@@ -296,7 +296,7 @@ MRUNTIME=$(MDATA)/$(RTS)
 MCABALBIN=$(MCABAL)/bin
 MDIST=dist-mcabal
 BASE=base-$(VERSION)
-BASEMODULES=Control.Applicative Control.Arrow Control.Category Control.DeepSeq Control.Error Control.Exception Control.Exception.Base Control.Monad Control.Monad.Fail Control.Monad.Fix Control.Monad.IO.Class Control.Monad.ST Control.Monad.Zip Data.Array Data.Bifoldable Data.Bifunctor Data.Bitraversable Data.Bits Data.Bool Data.Bounded Data.ByteString Data.Char Data.Complex Data.Constraint Data.Data Data.Double Data.Dynamic Data.Either Data.Enum Data.Eq Data.Fixed Data.Float Data.FloatW Data.Floating Data.Foldable Data.Foldable1 Data.Fractional Data.Function Data.Functor Data.Functor.Classes Data.Functor.Compose Data.Functor.Const Data.Functor.Contravariant Data.Functor.Identity Data.Functor.Product Data.Functor.Sum Data.Hashable Data.IOArray Data.IORef Data.Int Data.Integer Data.Integral Data.Ix Data.Kind Data.List Data.List.NonEmpty Data.Maybe Data.Monoid Data.Num Data.Ord Data.Proxy Data.Ratio Data.Real Data.RealFloat Data.RealFrac Data.Records Data.STRef Data.Semigroup Data.String Data.Text Data.Traversable Data.Tuple Data.Tuple.Instances Data.Type.Equality Data.TypeLits Data.Typeable Data.Version Data.Void Data.Word Data.ZipList Debug.Trace Foreign Foreign.C Foreign.C.Error Foreign.C.String Foreign.C.Types Foreign.ForeignPtr Foreign.Marshal Foreign.Marshal.Alloc Foreign.Marshal.Array Foreign.Marshal.Error Foreign.Marshal.Utils Foreign.Ptr Foreign.Storable GHC.Generics GHC.Stack GHC.Types Language.Haskell.TH.Syntax Mhs.Builtin Numeric Numeric.FormatFloat Numeric.Natural Prelude System.Cmd System.Console.GetOpt System.Compress System.Directory System.Environment System.Exit System.IO System.IO.Error System.IO.MD5 System.IO.PrintOrRun System.IO.Serialize System.IO.TimeMilli System.IO.Unsafe System.Info System.Process Text.Printf Text.ParserCombinators.ReadP Text.ParserCombinators.ReadPrec Text.Read Text.Read.Lex Text.Show Unsafe.Coerce
+BASEMODULES=Control.Applicative Control.Arrow Control.Category Control.DeepSeq Control.Error Control.Exception Control.Exception.Base Control.Monad Control.Monad.Fail Control.Monad.Fix Control.Monad.IO.Class Control.Monad.ST Control.Monad.Zip Data.Array Data.Bifoldable Data.Bifunctor Data.Bitraversable Data.Bits Data.Bool Data.Bounded Data.ByteString Data.Char Data.Complex Data.Constraint Data.Data Data.Double Data.Dynamic Data.Either Data.Enum Data.Eq Data.Fixed Data.Float Data.FloatW Data.Floating Data.Foldable Data.Foldable1 Data.Fractional Data.Function Data.Functor Data.Functor.Classes Data.Functor.Compose Data.Functor.Const Data.Functor.Contravariant Data.Functor.Identity Data.Functor.Product Data.Functor.Sum Data.Hashable Data.IOArray Data.IORef Data.Int Data.Integer Data.Integral Data.Ix Data.Kind Data.List Data.List.NonEmpty Data.Maybe Data.Monoid Data.Num Data.Ord Data.Proxy Data.Ratio Data.Real Data.RealFloat Data.RealFrac Data.Records Data.STRef Data.Semigroup Data.String Data.Text Data.Traversable Data.Tuple Data.Tuple.Instances Data.Type.Equality Data.TypeLits Data.Typeable Data.Version Data.Void Data.Word Data.ZipList Debug.Trace Foreign Foreign.C Foreign.C.Error Foreign.C.String Foreign.C.Types Foreign.ForeignPtr Foreign.Marshal Foreign.Marshal.Alloc Foreign.Marshal.Array Foreign.Marshal.Error Foreign.Marshal.Utils Foreign.Ptr Foreign.Storable GHC.Exts GHC.Generics GHC.Stack Language.Haskell.TH.Syntax Mhs.Builtin Numeric Numeric.FormatFloat Numeric.Natural Prelude System.Cmd System.Console.GetOpt System.Compress System.Directory System.Environment System.Exit System.IO System.IO.Error System.IO.MD5 System.IO.PrintOrRun System.IO.Serialize System.IO.TimeMilli System.IO.Unsafe System.Info System.Process Text.Printf Text.ParserCombinators.ReadP Text.ParserCombinators.ReadPrec Text.Read Text.Read.Lex Text.Show Unsafe.Coerce
 
 $(MCABALBIN)/mhs: bin/mhs $(RTS)/*.[ch] targets.conf $(MDIST)/Paths_MicroHs.hs
 	@mkdir -p $(MCABALBIN)

--- a/MicroHs.cabal
+++ b/MicroHs.cabal
@@ -118,7 +118,6 @@ executable mhs
                        bytestring   >= 0.5 && < 0.20,
                        deepseq      >= 1.1 && < 1.8,
                        filepath     >= 1.1 && < 1.8,
-                       ghc-prim     >= 0.5 && < 0.15,
                        haskeline    >= 0.8 && < 0.10,
                        time         >= 1.9 && < 1.20,
                        process      >= 1.6 && < 1.10,
@@ -144,38 +143,38 @@ library
                        -fwrite-ide-info -Wno-deprecations
   autogen-modules:     Paths_MicroHs
   exposed-modules:
-                        MicroHs.Abstract 
-                        MicroHs.Builtin 
-                        MicroHs.Compile 
-                        MicroHs.CompileCache 
-                        MicroHs.Deriving 
-                        MicroHs.Desugar 
-                        MicroHs.EncodeData 
-                        MicroHs.Exp 
-                        MicroHs.ExpPrint 
-                        MicroHs.Expr 
-                        MicroHs.FFI 
-                        MicroHs.Fixity 
-                        MicroHs.Flags 
-                        MicroHs.Graph 
-                        MicroHs.Ident 
-                        MicroHs.IdentMap 
-                        MicroHs.Interactive 
-                        MicroHs.IntMap 
-                        MicroHs.IntSet 
-                        MicroHs.Lex 
-                        MicroHs.List 
-                        MicroHs.Main 
-                        MicroHs.MakeCArray 
-                        MicroHs.Names 
-                        MicroHs.Package 
-                        MicroHs.Parse 
-                        MicroHs.State 
-                        MicroHs.StateIO 
-                        MicroHs.SymTab 
-                        MicroHs.TargetConfig 
-                        MicroHs.TCMonad 
-                        MicroHs.Translate 
+                        MicroHs.Abstract
+                        MicroHs.Builtin
+                        MicroHs.Compile
+                        MicroHs.CompileCache
+                        MicroHs.Deriving
+                        MicroHs.Desugar
+                        MicroHs.EncodeData
+                        MicroHs.Exp
+                        MicroHs.ExpPrint
+                        MicroHs.Expr
+                        MicroHs.FFI
+                        MicroHs.Fixity
+                        MicroHs.Flags
+                        MicroHs.Graph
+                        MicroHs.Ident
+                        MicroHs.IdentMap
+                        MicroHs.Interactive
+                        MicroHs.IntMap
+                        MicroHs.IntSet
+                        MicroHs.Lex
+                        MicroHs.List
+                        MicroHs.Main
+                        MicroHs.MakeCArray
+                        MicroHs.Names
+                        MicroHs.Package
+                        MicroHs.Parse
+                        MicroHs.State
+                        MicroHs.StateIO
+                        MicroHs.SymTab
+                        MicroHs.TargetConfig
+                        MicroHs.TCMonad
+                        MicroHs.Translate
                         MicroHs.TypeCheck
                         MhsEval
 
@@ -197,7 +196,6 @@ library
                         bytestring   >= 0.5 && < 0.20,
                         deepseq      >= 1.1 && < 1.8,
                         filepath     >= 1.1 && < 1.8,
-                        ghc-prim     >= 0.5 && < 0.15,
                         haskeline    >= 0.8 && < 0.10,
                         time         >= 1.9 && < 1.20,
                         process      >= 1.6 && < 1.10,

--- a/ghc/MHSPrelude.hs
+++ b/ghc/MHSPrelude.hs
@@ -10,7 +10,7 @@ import Data.Maybe
 import Data.List
 import Data.Text(Text, append, pack)
 import GHC.Stack
-import GHC.Types
+import Data.Kind
 import System.Environment
 import System.IO
 

--- a/ghc/PrimTable.hs
+++ b/ghc/PrimTable.hs
@@ -8,7 +8,7 @@ import Data.Word
 import System.IO
 import System.IO.TimeMilli
 import Unsafe.Coerce
-import GHC.Types(Any)
+import GHC.Exts(Any)
 import Foreign.C.String
 import Foreign.C.Types
 import Foreign.Marshal.Alloc

--- a/hugs/GHC/Exts.hs
+++ b/hugs/GHC/Exts.hs
@@ -1,0 +1,2 @@
+module GHC.Exts where
+data Any

--- a/hugs/GHC/Types.hs
+++ b/hugs/GHC/Types.hs
@@ -1,2 +1,0 @@
-module GHC.Types where
-data Any

--- a/hugs/PrimTable.hs
+++ b/hugs/PrimTable.hs
@@ -7,7 +7,7 @@ import Data.Word
 import System.IO
 import System.IO.TimeMilli
 import Unsafe.Coerce
-import GHC.Types(Any)
+import GHC.Exts(Any)
 import Foreign.C.String
 import Foreign.C.Types
 import Foreign.Marshal.Alloc


### PR DESCRIPTION
It is not necessary and also not recommended to depend on `ghc-prim`.