### PR TITLE
Changes required for compiling `distributive`

### DIFF
--- a/lib/Control/WrappedMonad.hs-boot
+++ b/lib/Control/WrappedMonad.hs-boot
@@ -1,6 +1,7 @@
 module Control.WrappedMonad where
 import qualified Prelude()
+import Data.Records
 
-newtype WrappedMonad m a = WrapMonad (m a)
+newtype WrappedMonad m a = WrapMonad { unwrapMonad :: m a }
 
-newtype WrappedArrow a b c = WrapArrow (a b c)
+newtype WrappedArrow a b c = WrapArrow { unwrapArrow :: a b c }

--- a/lib/Data/Complex.hs
+++ b/lib/Data/Complex.hs
@@ -10,6 +10,7 @@ module Data.Complex (
   conjugate,
 ) where
 
+import Data.Data
 import Data.Typeable
 import Text.ParserCombinators.ReadPrec
 import Text.Read.Internal
@@ -17,8 +18,19 @@ import qualified Text.Read.Lex as L
 
 infix 6 :+
 
-data Complex a = !a :+ !a
-  deriving (Typeable, Eq, Read, Show)
+data Complex a
+  = !a :+ !a    -- ^ forms a complex number from its real and imaginary
+                -- rectangular components.
+        deriving ( Eq
+                 , Show
+                 , Read
+                 , Data
+--                 , Generic
+--                 , Generic1
+                 , Functor
+                 , Foldable
+                 , Traversable
+                 )
 
 realPart :: forall a . Complex a -> a
 realPart (x :+ _) =  x
@@ -139,3 +151,32 @@ instance (RealFloat a) => Floating (Complex a) where
       , v <- sin (b/2)
       , w <- -(2*v*v) = (u*w + u + w) :+ (u+1)*sin b
       | otherwise = exp x - 1
+
+{-
+instance Storable a => Storable (Complex a) where
+    sizeOf a       = 2 * sizeOf (realPart a)
+    alignment a    = alignment (realPart a)
+    peek p           = do
+                        q <- return $ castPtr p
+                        r <- peek q
+                        i <- peekElemOff q 1
+                        return (r :+ i)
+    poke p (r :+ i)  = do
+                        q <-return $  (castPtr p)
+                        poke q r
+                        pokeElemOff q 1 i
+
+instance Applicative Complex where
+  pure a = a :+ a
+  f :+ g <*> a :+ b = f a :+ g b
+  liftA2 f (x :+ y) (a :+ b) = f x a :+ f y b
+
+instance Monad Complex where
+  a :+ b >>= f = realPart (f a) :+ imagPart (f b)
+
+instance MonadZip Complex where
+  mzipWith = liftA2
+
+instance MonadFix Complex where
+  mfix f = (let a :+ _ = f a in a) :+ (let _ :+ a = f a in a)
+-}

--- a/lib/Data/Monoid/Internal.hs
+++ b/lib/Data/Monoid/Internal.hs
@@ -40,10 +40,10 @@ instance (Semigroup b) => Semigroup (a -> b) where
 
 newtype Endo a = Endo { appEndo :: a -> a }
 
-instance forall a . Semigroup (Endo a) where
+instance Semigroup (Endo a) where
   Endo f <> Endo g = Endo (f . g)
 
-instance forall a . Monoid (Endo a) where
+instance Monoid (Endo a) where
   mempty = Endo id
 
 ---------------------
@@ -51,64 +51,92 @@ instance forall a . Monoid (Endo a) where
 newtype Dual a = Dual { getDual :: a }
   deriving (Bounded, Eq, Ord, Show)
 
-instance forall a . Semigroup a => Semigroup (Dual a) where
+instance Semigroup a => Semigroup (Dual a) where
   Dual a <> Dual b = Dual (b <> a)
 
-instance forall a . Monoid a => Monoid (Dual a) where
+instance Monoid a => Monoid (Dual a) where
   mempty = Dual mempty
 
 instance Functor Dual where
-  fmap f (Dual a) = Dual (f a)
+  fmap = coerce
 
 instance Applicative Dual where
   pure = Dual
-  Dual f <*> Dual b = Dual (f b)
+  (<*>) = coerce
 
 ---------------------
 
 newtype Max a = Max { getMax :: a }
   deriving (Bounded, Eq, Ord, Show)
 
-instance forall a . Ord a => Semigroup (Max a) where
+instance Ord a => Semigroup (Max a) where
   Max a <> Max b = Max (a `max` b)
   stimes = stimesIdempotent
 
-instance forall a . (Ord a, Bounded a) => Monoid (Max a) where
+instance (Ord a, Bounded a) => Monoid (Max a) where
   mempty = Max minBound
+
+instance Functor Max where
+  fmap = coerce
+
+instance Applicative Max where
+  pure = Max
+  (<*>) = coerce
 
 ---------------------
 
 newtype Min a = Min { getMin :: a }
   deriving (Bounded, Eq, Ord, Show)
 
-instance forall a . Ord a => Semigroup (Min a) where
+instance Ord a => Semigroup (Min a) where
   Min a <> Min b = Min (a `min` b)
   stimes = stimesIdempotent
 
-instance forall a . (Ord a, Bounded a) => Monoid (Min a) where
+instance (Ord a, Bounded a) => Monoid (Min a) where
   mempty = Min maxBound
+
+instance Functor Min where
+  fmap = coerce
+
+instance Applicative Min where
+  pure = Min
+  (<*>) = coerce
 
 ---------------------
 
 newtype Sum a = Sum { getSum :: a }
   deriving (Bounded, Eq, Ord, Show, Num)
 
-instance forall a . Num a => Semigroup (Sum a) where
+instance Num a => Semigroup (Sum a) where
   Sum a <> Sum b = Sum (a + b)
 
-instance forall a . (Num a) => Monoid (Sum a) where
+instance (Num a) => Monoid (Sum a) where
   mempty = Sum 0
+
+instance Functor Sum where
+  fmap = coerce
+
+instance Applicative Sum where
+  pure = Sum
+  (<*>) = coerce
 
 ---------------------
 
 newtype Product a = Product { getProduct :: a }
   deriving (Bounded, Eq, Ord, Show, Num)
 
-instance forall a . Num a => Semigroup (Product a) where
+instance Num a => Semigroup (Product a) where
   Product a <> Product b = Product (a * b)
 
-instance forall a . (Num a) => Monoid (Product a) where
+instance (Num a) => Monoid (Product a) where
   mempty = Product 1
+
+instance Functor Product where
+  fmap = coerce
+
+instance Applicative Product where
+  pure = Product
+  (<*>) = coerce
 
 ---------------------
 


### PR DESCRIPTION
These changes are required to get `distributive` to compile (some CPP changes in the package are needed as well).
* Use record syntax for `WrappedMonad`, `WrappedArrow`
* Add `Complex` instances
* Add `Functor`, `Applicative` instances for `Max`, `Min`, `Sum`, `Product`
---
Some of the `Complex` instances are commented out, since they fail to parse. Specifically `f :+ g <*> a :+ b = ...` fails to parse. Should I open an issue for that?