### PR TITLE
Simplify `mdo` desugaring

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Differences:
    * PolymorphicComponents
    * RankNTypes
    * RecordWildCards
-   * RecursiveDo (just `rec`, not `mdo`)
+   * RecursiveDo (without optimal `mdo` desugaring)
    * RequiredTypeArguments
    * QualifiedDo
    * ScopedTypeVariables

--- a/src/MicroHs/Parse.hs
+++ b/src/MicroHs/Parse.hs
@@ -787,10 +787,7 @@ pDo = do
   if rec then
     case last ss of
       SThen e ->
-        let l = E.getSLoc e
-            x = EVar $ mkIdentSLoc l "$mdo"
-            pur = EVar (mkIdentSLoc l "B@.return")
-        in  pure $ EDo q [SRec (init ss ++ [SBind x e]), SThen (EApp pur x)]
+        pure $ EDo q [SRec (init ss), SThen e]
       _ -> fail "mdo"
    else
     pure (EDo q ss)


### PR DESCRIPTION
The final statement of an `mdo` block is always an `SThen`, there's no point in turning it into an `SBind`, since the `$mdo` variable can't be used anyway.