### PR TITLE
Some small changes to the CPP-bits of eval.c

### DIFF
--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -26,10 +26,14 @@
 #endif /* __EMSCRIPTEN__ */
 #if WANT_DIR
 #include <dirent.h>
-#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #endif  /* WANT_DIR */
+#if WANT_DIR || WANT_STDIO
+// The call `unlink` is guarded under WANT_STDIO, but the rest seems to be under WANT_DIR.
+// Lennart, how do you want to include unistd.h?
+#include <unistd.h>
+#endif
 #if WANT_TIME
 #include <time.h>
 #endif


### PR DESCRIPTION
I am compiling for a target (STM32L552) where I have this set of configs

```
#define WANT_STDIO 1
#define WANT_FLOAT32 1
#define WANT_MD5 0
#define WANT_TICK 0
#define WANT_ARGS 0
#define GCRED    0
#define FASTTAGS 1
#define INTTABLE 1
#define SANITY   1
#define STACKOVL 1

#define HEAP_CELLS 8000
#define STACK_SIZE 500
```

and there were some errors to take care of before compiling could proceed. I have executed `make everytest` without problem before opening this MR, but I don't yet know how these changes affect the other build targets (I guess CI will tell us).

There are two other problems that arises from this set of configurations, but I will open an issue describing them shortly, and we'll see what you want to do.