### PR TITLE
Fix several issues with unicode arrows

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -66,6 +66,7 @@
 - ignore: {name: Use section, within: [Deriving]}
 - ignore: {name: Use list literal, within: [ImpMet]}
 - ignore: {name: "Monoid law, left identity", within: [Builder]}
+- ignore: {name: "Redundant multi-way if", within: [Unicode]}
 
 - arguments:
     - --ignore-glob=lib/Data/Foldable1.hs

--- a/src/MicroHs/Ident.hs
+++ b/src/MicroHs/Ident.hs
@@ -146,7 +146,7 @@ headIdent (Ident _ i) = head i
 isConIdent :: Ident -> Bool
 isConIdent i@(Ident _ t) =
   let c = headIdent i
-  in  isUpperX c || c == ':' || c == ',' || t == pack "[]"  || t == pack "()" || t == pack "->"
+  in  isUpperX c || c == ':' || c == ',' || t == pack "[]"  || t == pack "()" || t == pack "->" || t == pack "\x2192"
 
 isOperChar :: Char -> Bool
 isOperChar '@' = True
@@ -200,8 +200,8 @@ slocFile :: SLoc -> FilePath
 slocFile (SLoc f _ _) = f
 
 isUpperX :: Char -> Bool
-isUpperX '\8658' = False  -- these two lines avoid using the whole Unicode machinery
-isUpperX '\8594' = False
+isUpperX '\x21d2' = False  -- these two lines avoid using the whole Unicode machinery
+isUpperX '\x2192' = False
 isUpperX c = isUpper c
 
 -- This is a hack to hide an identifier without removing it

--- a/src/MicroHs/Parse.hs
+++ b/src/MicroHs/Parse.hs
@@ -393,7 +393,7 @@ pPatSyn = do
        let eqn = eEqn (map (EVar . idKindIdent) vs) p
        pure (lhs, p, Just [eqn])
    ) <|> (
-    do pSymbol "<-"
+    do pSLArrow
        p <- pPat
        meqns <- optional (pKeyword "where" *> pBraces (pEqnsU i))
        pure (lhs, p, fmap snd meqns)
@@ -435,7 +435,7 @@ pGADTconstr = do
   es <- pForall
   ctx <- pContext
   let pGType = pStrictP $ pOperators pOper pTypeArg
-  args <- many (pGType <* pSymbol "->")
+  args <- many (pGType <* pSRArrow)
   res <- pType
   pure (cn, es, ctx, args, res)
 
@@ -583,7 +583,7 @@ pTypeArg :: P EType
 pTypeArg =
     do
       vs <- pForall'
-      q <- (QExpl <$ pSymbol ".") <|> (QReqd <$ pSymbol "->")
+      q <- (QExpl <$ pSymbol ".") <|> (QReqd <$ pSRArrow)
       EForall q vs <$> pType
   <|>
     pTypeApp
@@ -796,7 +796,7 @@ pIf :: P Expr
 pIf = EIf <$> (pKeyword "if" *> pExpr) <*>
               (optional (pSpec ';') *> pKeyword "then" *> pExpr) <*>
               (optional (pSpec ';') *> pKeyword "else" *> pExpr)
-  <|> EMultiIf <$> (EAlts <$> (pKeyword "if" *> pBlock (pAlt (pSymbol "->"))) <*> pure [])
+  <|> EMultiIf <$> (EAlts <$> (pKeyword "if" *> pBlock (pAlt pSRArrow)) <*> pure [])
 
 pQualDo :: P Ident
 pQualDo = do

--- a/tests/Unicode.hs
+++ b/tests/Unicode.hs
@@ -23,5 +23,17 @@ main = do
   printCases '\x2168' -- IX
   printCases '\x2178' -- ix
 
+data Option a where
+  Some ∷ a ⇒ Option a
+  None ∷ Option a
+
 foo ∷ ∀ α . Eq α ⇒ α → α
-foo x = if x == x then x else undefined
+foo x = if
+  | x == x → x
+  | otherwise → undefined
+
+bar ∷ ∀ α → (→) α α
+bar _ = id
+
+pattern Sings ∷ a → [a] → [a]
+pattern Sings a as ← as@[a]


### PR DESCRIPTION
Replace `pSymbol "<-"` with `pSLArrow` and `pSymbol "->"` with `pSRArrow`. Also make `"\x2192"` (`→`) a con ident, so that `(→)` gets interpreted correctly.