### PR TITLE
 Add Data.Text.replace

### DIFF
--- a/lib/Data/Text.hs
+++ b/lib/Data/Text.hs
@@ -30,6 +30,7 @@ module Data.Text(
   isPrefixOf,
   isSuffixOf,
   isInfixOf,
+  replace,
   map,
   ) where
 import qualified Prelude(); import MiniPrelude hiding(head, tail, null, length, words, map)
@@ -155,6 +156,9 @@ intercalate :: Text -> [Text] -> Text
 intercalate _ [] = empty
 intercalate _ [x] = x
 intercalate s (x:xs) = x `append` s `append` intercalate s xs
+
+replace :: Text -> Text -> Text -> Text
+replace s r = intercalate r . splitOn s
 
 -- XXX Should make the BS version efficient and go via that
 isPrefixOf :: Text -> Text -> Bool


### PR DESCRIPTION
`granite-0.4.0.0` added a (very nice) `svg` backend which uses `Data.Text.replace`, presently missing. Since `granite` is also used in the ` hackage-ci` workflow I thought it was worth fixing ASAP. 