### PR TITLE
SimpleReadline: instead of using `error` return \NUL when getRaw fails

### DIFF
--- a/mhs/System/Console/SimpleReadline.hs
+++ b/mhs/System/Console/SimpleReadline.hs
@@ -50,9 +50,9 @@ getInputLineHistComp comp hfn prompt = do
 getRaw :: IO Char
 getRaw = do
   i <- c_getRaw
-  when (i < 0) $
-    error "getRaw failed"
-  return (chr i)
+  if i < 0
+    then return (chr 0)
+    else return (chr i)
 
 -- The history.
 -- before: the inputs before the current input


### PR DESCRIPTION
Since `getraw` in `extra.c` only reads a single byte, everytime I press a key producing a multi byte utf8 character, which may happen quite commonly, even by mistake, in an Italian keyboard, the `repl` will die with that error message. I thought the returning a \NUL instead would be more appropriate.