### PR TITLE
SimpleReadline: handle additional escape sequences (Delete, Home, End)

### DIFF
--- a/mhs/System/Console/SimpleReadline.hs
+++ b/mhs/System/Console/SimpleReadline.hs
@@ -221,6 +221,15 @@ loop' comp hist before after cmd = do
               'B' -> next
               'C' -> forward
               'D' -> backward
+              'F' -> eol
+              'H' -> bol
+              _ | isDigit c -> do
+                    d <- getRaw
+                    case (c,d) of
+                      ('1','~') -> bol
+                      ('3','~') -> del
+                      ('4','~') -> eol
+                      _         -> noop
               _   -> noop
         _ -> if i >= ' ' && i < '\DEL' then add i else noop
 


### PR DESCRIPTION
This PR adds `Home`, `End` (in their different common sequences) and `Delete` to the `SimpleReadline` library. I was really missing the last one.

ps: sorry for flooding you with these PRs while in the midst of the `typefamily` transition.