### PR TITLE
Fix almost all Hugs incompatibilities

### DIFF
--- a/hugs/Data/Semigroup.hs
+++ b/hugs/Data/Semigroup.hs
@@ -18,11 +18,11 @@ class Semigroup a where
     | otherwise = f x0 y0
     where
       f x y
-        | even y == 0 = f (x <> x) (y `quot` 2)
+        | even y = f (x <> x) (y `quot` 2)
         | y == 1 = x
         | otherwise = g (x <> x) (y `quot` 2) x
       g x y z
-        | even y == 0 = g (x <> x) (y `quot` 2) z
+        | even y = g (x <> x) (y `quot` 2) z
         | y == 1 = x <> z
         | otherwise = g (x <> x) (y `quot` 2) (x <> z)
 

--- a/hugs/Data/String.hs
+++ b/hugs/Data/String.hs
@@ -1,0 +1,17 @@
+module Data.String(
+  IsString(..),
+  String,
+  lines, unlines,
+  words, unwords,
+  ) where
+
+import qualified Data.ByteString.Char8 as BS8
+
+class IsString a where
+  fromString :: String -> a
+
+instance IsString [Char] where
+  fromString s = s
+
+instance IsString BS8.ByteString where
+  fromString = BS8.pack

--- a/hugs/Data/Text.hs
+++ b/hugs/Data/Text.hs
@@ -8,6 +8,7 @@ module Data.Text(
   null,
   head,
   tail,
+  cons,
   uncons,
   ) where
 import Prelude hiding(head, tail, null)
@@ -63,6 +64,9 @@ head (T t) = Prelude.head t
 
 tail :: Text -> Text
 tail (T t) = T (Prelude.tail t)
+
+cons :: Char -> Text -> Text
+cons c (T t) = T (c : t)
 
 uncons :: Text -> Maybe (Char, Text)
 uncons t | null t    = Nothing

--- a/hugs/MHSPrelude.hs
+++ b/hugs/MHSPrelude.hs
@@ -7,7 +7,7 @@ module MHSPrelude(
   module Control.Arrow,
   module Data.Monoid,
   module Data.Semigroup,
-  (<$>), Applicative(..), (*>),
+  (<$>), Applicative(..), (*>), (<*), (>=>), (<=<)
   ) where
 import Hugs.Prelude()
 import Prelude hiding(fail)
@@ -55,6 +55,12 @@ spanEnd p xs = (dropWhileEnd p xs, takeWhileEnd p xs)
 
 breakEnd :: (a -> Bool) -> [a] -> ([a], [a])
 breakEnd p = spanEnd (not . p)
+
+subsequences :: [a] -> [[a]]
+subsequences xs = [] : sub xs
+  where sub []     = []
+        sub (x:xs) = [x] : foldr f [] (sub xs)
+          where f ys r = ys : (x : ys) : r
 
 ------- Version --------
 
@@ -231,3 +237,11 @@ instance NFData MD5CheckSum
 
 class HasCallStack
 instance HasCallStack
+
+(<=<) :: forall m a b c . Monad m => (b -> m c) -> (a -> m b) -> (a -> m c)
+f <=< g = \ a -> do
+  b <- g a
+  f b
+
+(>=>) :: forall m a b c . Monad m => (a -> m b) -> (b -> m c) -> (a -> m c)
+(>=>) = flip (<=<)

--- a/hugs/MHSPrelude.hs
+++ b/hugs/MHSPrelude.hs
@@ -16,6 +16,7 @@ import Control.Arrow(first, second)
 import Control.Applicative
 import Control.Exception(Exception, try)
 --import Control.Monad.Fail
+import Data.Int
 import Data.List
 import Data.Maybe
 import Data.Monoid
@@ -193,6 +194,7 @@ force :: (NFData a) => a -> a
 force x = x `deepseq` x
 
 instance NFData Int
+instance NFData Int64
 instance NFData Word
 instance NFData Float
 instance NFData Double

--- a/hugs/MHSPrelude.hs
+++ b/hugs/MHSPrelude.hs
@@ -4,7 +4,8 @@ module MHSPrelude(
   module Prelude,
   module MHSPrelude,
 --  module Control.Monad.Fail,
-  module Control.Arrow,
+  -- Exporting these with 'module Control.Arrow' does not work
+  first, second,
   module Data.Monoid,
   module Data.Semigroup,
   (<$>), Applicative(..), (*>), (<*), (>=>), (<=<)

--- a/src/MicroHs/Compile.hs
+++ b/src/MicroHs/Compile.hs
@@ -259,9 +259,9 @@ compileModuleP flags impt mdl@(EModule _ _ defs) = do
   return ((dmdl, syms, imported, tThis, tImp), tcstate)
 
 compileToCombinators :: TModule [LDef] -> TModule [LDef]
-compileToCombinators dmdl = do
+compileToCombinators dmdl =
   let cmdl = setBindings dmdl [ (i, compileOpt e) | (i, e) <- tBindingsOf dmdl ]
-  seq (rnf cmdl) cmdl  -- This makes execution slower, but speeds up GC
+  in seq (rnf cmdl) cmdl  -- This makes execution slower, but speeds up GC
 
 -- Add implicit imports:
 --   import Prelude

--- a/src/MicroHs/Expr.hs
+++ b/src/MicroHs/Expr.hs
@@ -58,6 +58,7 @@ module MicroHs.Expr(
   dropForallContext,
   ) where
 import qualified Prelude(); import MHSPrelude
+import Data.Int
 import Data.List
 import Data.Maybe
 import MicroHs.Builtin

--- a/src/MicroHs/Parse.hs
+++ b/src/MicroHs/Parse.hs
@@ -810,7 +810,7 @@ pDo = do
     case last ss of
       SThen e ->
         pure $ EDo q [SRec (init ss), SThen e]
-      _ -> fail "mdo"
+      _ -> Control.Monad.Fail.fail "mdo"
    else
     pure (EDo q ss)
 

--- a/src/Text/ParserComb.hs
+++ b/src/Text/ParserComb.hs
@@ -115,7 +115,7 @@ instance TokenMachine tm t => Alternative (Prsr tm t) where
       r -> r
 
 instance TokenMachine tm t => MonadPlus (Prsr tm t) where
-  mzero = fail "mzero"
+  mzero = F.fail "mzero"
   mplus = (<|>)
 
 satisfy :: forall tm t . TokenMachine tm t => String -> (t -> Bool) -> Prsr tm t t


### PR DESCRIPTION
The only thing this PR doesn't fix is the use of patterns that Hugs cannot parse (`ViewPatterns` and commas in guards).

I do have a patch for the incompatible patterns, but it involves a lot of `isJust` and `fromJust` so I have omitted it here.
Please let me know if you're interested in that change despite its flaws.

I tested this against `v0.15.4.0` and then rebased the fixes onto `master`, so this doesn't address any incompatibilities added to `master` since `v0.15.4.0`.