### PR TITLE
Remove redundant import of Data.Coerce

### DIFF
--- a/mhs/MHSPrelude.hs
+++ b/mhs/MHSPrelude.hs
@@ -7,6 +7,7 @@ module MHSPrelude(
   module Data.Bool,
   module Data.Bounded,
   module Data.Char,
+  module Data.Coerce,
   module Data.Double,
   module Data.Either,
   module Data.Enum,
@@ -52,6 +53,7 @@ import Control.Monad.Fail(MonadFail(..))
 import Data.Bool(Bool(..), (&&), (||), not, otherwise)
 import Data.Bounded(Bounded(..))
 import Data.Char(Char, String)
+import Data.Coerce(coerce)
 import Data.Double(Double)
 import Data.Either(Either(..), either)
 import Data.Enum(Enum(..))

--- a/src/Text/PrettyPrint/HughesPJLiteClass.hs
+++ b/src/Text/PrettyPrint/HughesPJLiteClass.hs
@@ -28,7 +28,6 @@ module Text.PrettyPrint.HughesPJLiteClass (
     module Text.PrettyPrint.HughesPJLite
   ) where
 import qualified Prelude(); import MHSPrelude
-import Data.Coerce
 
 import Text.PrettyPrint.HughesPJLite
 


### PR DESCRIPTION
This import is problematic when running under Hugs.
It is needed under MicroHs due to how deriving is implemented.