### PR TITLE
Fix runtime configs using old `WANT_FLOAT` setting

### DIFF
--- a/src/runtime/c64/config.h
+++ b/src/runtime/c64/config.h
@@ -10,9 +10,16 @@
 
 /*
  * Include ops for floating point arithmetic.
- * Without this +,-,* etc will not be available for the Double type.
+ * Without this +,-,* etc will not be available for the Float type.
  */
-#define WANT_FLOAT 0
+#define WANT_FLOAT32 0
+
+/*
+ * Include ops for floating point arithmetic.
+ * Without this +,-,* etc will not be available for the Double type.
+ * Using this on a 32 bit platform will make cells be 12 bytes instead of 8,
+ */
+#define WANT_FLOAT64 0
 
 /*
  * Include <math.h>

--- a/src/runtime/esp32/config.h
+++ b/src/runtime/esp32/config.h
@@ -10,9 +10,16 @@
 
 /*
  * Include ops for floating point arithmetic.
- * Without this +,-,* etc will not be available for the Double type.
+ * Without this +,-,* etc will not be available for the Float type.
  */
-#define WANT_FLOAT 1
+#define WANT_FLOAT32 1
+
+/*
+ * Include ops for floating point arithmetic.
+ * Without this +,-,* etc will not be available for the Double type.
+ * Using this on a 32 bit platform will make cells be 12 bytes instead of 8,
+ */
+#define WANT_FLOAT64 0
 
 /*
  * Include <math.h>

--- a/src/runtime/micro/config.h
+++ b/src/runtime/micro/config.h
@@ -42,9 +42,16 @@
 
 /*
  * Include ops for floating point arithmetic.
- * Without this +,-,* etc will not be available for the Double type.
+ * Without this +,-,* etc will not be available for the Float type.
  */
-#define WANT_FLOAT 0
+#define WANT_FLOAT32 0
+
+/*
+ * Include ops for floating point arithmetic.
+ * Without this +,-,* etc will not be available for the Double type.
+ * Using this on a 32 bit platform will make cells be 12 bytes instead of 8,
+ */
+#define WANT_FLOAT64 0
 
 /*
  * Include <math.h>

--- a/src/runtime/mingw/config.h
+++ b/src/runtime/mingw/config.h
@@ -10,9 +10,16 @@
 
 /*
  * Include ops for floating point arithmetic.
- * Without this +,-,* etc will not be available for the Double type.
+ * Without this +,-,* etc will not be available for the Float type.
  */
-#define WANT_FLOAT 1
+#define WANT_FLOAT32 1
+
+/*
+ * Include ops for floating point arithmetic.
+ * Without this +,-,* etc will not be available for the Double type.
+ * Using this on a 32 bit platform will make cells be 12 bytes instead of 8,
+ */
+#define WANT_FLOAT64 0
 
 /*
  * Include <math.h>

--- a/src/runtime/stm32f4/config.h
+++ b/src/runtime/stm32f4/config.h
@@ -10,9 +10,16 @@
 
 /*
  * Include ops for floating point arithmetic.
- * Without this +,-,* etc will not be available for the Double type.
+ * Without this +,-,* etc will not be available for the Float type.
  */
-#define WANT_FLOAT 1
+#define WANT_FLOAT32 1
+
+/*
+ * Include ops for floating point arithmetic.
+ * Without this +,-,* etc will not be available for the Double type.
+ * Using this on a 32 bit platform will make cells be 12 bytes instead of 8,
+ */
+#define WANT_FLOAT64 0
 
 /*
  * Include <math.h>


### PR DESCRIPTION
`WANT_FLOAT` isn't used anymore, but is still set in runtime configs, so this replaces use of WANT_FLOAT with WANT_FLOAT32 and 64.