### PR TITLE
fix bug with Paths_MicroHs not being regenerated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ $(MCABALBIN)/mhs: bin/mhs $(RTS)/*.[ch] targets.conf $(MDIST)/Paths_MicroHs.hs m
 	cp targets.conf $(MDATA)
 	cp -r $(RTS)/* $(MRUNTIME)
 
-$(MDIST)/Paths_MicroHs.hs:
+$(MDIST)/Paths_MicroHs.hs: Makefile
 	@mkdir -p $(MDIST)
 	@echo 'module Paths_MicroHs where { import qualified Prelude(); import MHSPrelude; import Data.Version; version :: Version; version = makeVersion [$(HVERSION)]; getDataDir :: IO FilePath; getDataDir = return "$(MDATA)" }' > $(MDIST)/Paths_MicroHs.hs
 


### PR DESCRIPTION
It is built in `dist-mcabal/` per the Makefile. Its contents are created from variables in the Makefile. The rule to built it, however, has no prerequisites.

I had forked and installed mhs when the version was `0.14.x.x`, and thus had a `Paths_MicroHs.hs` in there that contained these versions. When I pulled and rebuilt/installed the compiler after the version had bumped to `0.15.x.x`, this file was not regenerated (as my `dist-mcabal/` remained from before).

Installation proceeded as expected and without errors, but at runtime there were discrepancies. I had made changes to `eval.c` that never appeared at runtime. Things were copied over during installation to both `~/.mcabal/mhs-0.15.5.0/` and `~/.mcabal/mhs-0.15.4.0/`. I didn't dig into exactly what went were, but this one-liner seemed to fix it. Nightmare to narrow down this issue!

I don't know if this is the correct fix, please advise @augustss 