### PR TITLE
Fix deriving not using builtin identifiers

### DIFF
--- a/lib/Mhs/Builtin.hs
+++ b/lib/Mhs/Builtin.hs
@@ -1,22 +1,27 @@
 -- Copyright 2023-2025 Lennart Augustsson
 -- See LICENSE file for full license.
 module Mhs.Builtin(
+  module Control.Applicative,
+  module Control.Error,
   module Control.Monad,
   module Control.Monad.Fail,
   module Control.Monad.Fix,
   module Data.Bool,
+  module Data.Bounded,
   module Data.Char,
   module Data.Coerce,
   module Data.Data_Class,
-  module Data.Enum,
+  module Data.Enum_Class,
   module Data.Eq,
 --  module Data.Foldable,
   module Data.Fractional,
   module Data.Function,
   module Data.Functor,
+  module Data.Ix,
   module Data.Ord,
   module Data.Num,
   module Data.Records,
+  module Data.Traversable,
   module Data.Typeable,
   module Data.Monoid.Internal,
   module Data.Proxy,
@@ -35,22 +40,24 @@ module Mhs.Builtin(
 -- qualified, but under a name that cannot be used accidentally.
 -- If the Prelude is not imported, then neither is this module.
 import qualified Prelude()  -- no Prelude
-import Control.Applicative(Applicative((<*>)))
+import Control.Applicative(Applicative(pure, (<*>)))
 import Control.Error(error)
 import Control.Monad(Monad(..))
 import Control.Monad.Fail(MonadFail(..))
 import {-# SOURCE #-} Control.Monad.Fix(_mfix)
 import Data.Bool((&&), Bool(..))
+import Data.Bounded(Bounded(..))
 import Data.Char(Char)
 import Data.Coerce(Coercible, coerce)
 import Data.Data_Class(Data(..), Fixity(..), mkDataType, mkConstrTag, constrIndex)
-import Data.Enum(Enum(enumFrom, enumFromThen, enumFromTo, enumFromThenTo))
+import Data.Enum_Class(Enum(enumFrom, enumFromThen, enumFromTo, enumFromThenTo, fromEnum))
 import Data.Eq(Eq(..))
 --import Data.Foldable(Foldable(..))
 import qualified Data.Foldable
 import Data.Fractional(Fractional(fromRational))
 import Data.Function((.), id, flip)
 import Data.Functor(Functor(..), (<$>))
+import Data.Ix(Ix(range, unsafeIndex, inRange, unsafeRangeSize))
 import Data.Ord(Ord(..), Ordering(..))
 import Data.Num(Num((+), (-), (*), fromInteger, negate))
 import Data.Proxy(Proxy(..))

--- a/src/MicroHs/Deriving.hs
+++ b/src/MicroHs/Deriving.hs
@@ -326,12 +326,14 @@ derBounded mctx 0 lhs cs@(c0:_) ebnd = do
   let loc = getSLoc ebnd
       mkEqn bnd (Constr _ _ c _ flds) =
         let n = either length length flds
-        in  eEqn [] $ tApps c (replicate n (EVar bnd))
+        in  eEqn [] $ tApps c (replicate n bnd)
 
       iMinBound = mkIdentSLoc loc "minBound"
       iMaxBound = mkIdentSLoc loc "maxBound"
-      minEqn = mkEqn iMinBound c0
-      maxEqn = mkEqn iMaxBound (last cs)
+      eMinBound = EVar (mkBuiltin loc "minBound")
+      eMaxBound = EVar (mkBuiltin loc "maxBound")
+      minEqn = mkEqn eMinBound c0
+      maxEqn = mkEqn eMaxBound (last cs)
       inst = Instance hdr [Fcn iMinBound [minEqn], Fcn iMaxBound [maxEqn]] []
   -- traceM $ showEDefs [inst]
   return [inst]
@@ -348,21 +350,22 @@ derEnum mctx 0 lhs cs@(c0:_) enm | all isNullary cs = do
       eLastCon = case last cs of Constr _ _ c _ _ -> tCon c
 
       iFromEnum = mkIdentSLoc loc "fromEnum"
+      eFromEnum = eAppI (mkBuiltin loc "fromEnum")
       iToEnum = mkIdentSLoc loc "toEnum"
       iEnumFrom = mkIdentSLoc loc "enumFrom"
       iEnumFromThen = mkIdentSLoc loc "enumFromThen"
-      iEnumFromTo = mkBuiltin loc "enumFromTo"
-      iEnumFromThenTo = mkBuiltin loc "enumFromThenTo"
+      eEnumFromTo = eAppI2 (mkBuiltin loc "enumFromTo")
+      eEnumFromThenTo = eAppI3 (mkBuiltin loc "enumFromThenTo")
       enumFromEqn =
         -- enumFrom x = enumFromTo x (last cs)
         let x = EVar (mkIdentSLoc loc "x")
-        in eEqn [x] (eAppI2 iEnumFromTo x eLastCon)
+        in eEqn [x] (eEnumFromTo x eLastCon)
       enumFromThenEqn =
         -- enumFromThen x1 x2 = if fromEnum x2 >= fromEnum x1 then enumFromThenTo x1 x2 (last cs) else enumFromThenTo x1 x2 (head cs)
         let
           x1 = EVar (mkIdentSLoc loc "x1")
           x2 = EVar (mkIdentSLoc loc "x2")
-        in eEqn [x1, x2] (EIf (eAppI2 (mkBuiltin loc ">=") (EApp (EVar iFromEnum) x2) (EApp (EVar iFromEnum) x1)) (eAppI3 iEnumFromThenTo x1 x2 eLastCon) (eAppI3 iEnumFromThenTo x1 x2 eFirstCon))
+        in eEqn [x1, x2] (EIf (eAppI2 (mkBuiltin loc ">=") (eFromEnum x2) (eFromEnum x1)) (eEnumFromThenTo x1 x2 eLastCon) (eEnumFromThenTo x1 x2 eFirstCon))
       inst = Instance hdr [Fcn iFromEnum (fromEnumEqns loc cs), Fcn iToEnum (toEnumEqns loc cs), Fcn iEnumFrom [enumFromEqn], Fcn iEnumFromThen [enumFromThenEqn]] []
   return [inst]
 derEnum _ _ lhs _ e = cannotDerive lhs e
@@ -412,16 +415,19 @@ derIx mctx 0 lhs cs@(c0:cs') eix = do
         eAnd = eAppI2 (mkBuiltin loc "&&")
         eAdd = eAppI2 (mkBuiltin loc "+")
         eMul = eAppI2 (mkBuiltin loc "*")
-        iUnsafeRangeSize = mkIdentSLoc loc "unsafeRangeSize"
+        eRange           = eAppI  (mkBuiltin loc "range")
+        eUnsafeIndex     = eAppI2 (mkBuiltin loc "unsafeIndex")
+        eInRange         = eAppI2 (mkBuiltin loc "inRange")
+        eUnsafeRangeSize = eAppI  (mkBuiltin loc "unsafeRangeSize")
         (xp, xs) = mkPat c0 "x$"
         (yp, ys) = mkPat c0 "y$"
         (zp, zs) = mkPat c0 "z$"
-        rangeEqn = eEqn [ETuple [xp, yp]] $ EListish (LCompr (tApps iC0 zs) (zipWith3 (\x y z -> SBind z (eAppI iRange (ETuple [x, y]))) xs ys zs))
+        rangeEqn = eEqn [ETuple [xp, yp]] $ EListish (LCompr (tApps iC0 zs) (zipWith3 (\x y z -> SBind z (eRange (ETuple [x, y]))) xs ys zs))
         unsafeIndexEqn =
-          let mkUnsafeIndex x y z = eAppI2 iUnsafeIndex (ETuple [x, y]) z
-              mkUnsafeRangeSize x y = eAppI iUnsafeRangeSize (ETuple [x, y])
+          let mkUnsafeIndex x y z = eUnsafeIndex (ETuple [x, y]) z
+              mkUnsafeRangeSize x y = eUnsafeRangeSize (ETuple [x, y])
           in eEqn [ETuple [xp, yp], zp] $ foldl (\ acc (x, y, z) -> eAdd (mkUnsafeIndex x y z) (eMul (mkUnsafeRangeSize x y) acc)) (mkUnsafeIndex (head xs) (head ys) (head zs)) $ zip3 (tail xs) (tail ys) (tail zs)
-        inRangeEqn = eEqn [ETuple [xp, yp], zp] $ foldr1 eAnd $ zipWith3 (\x y z -> eAppI2 iInRange (ETuple [x, y]) z) xs ys zs
+        inRangeEqn = eEqn [ETuple [xp, yp], zp] $ foldr1 eAnd $ zipWith3 (\x y z -> eInRange (ETuple [x, y]) z) xs ys zs
         inst = Instance hdr [Fcn iRange [rangeEqn], Fcn iUnsafeIndex [unsafeIndexEqn], Fcn iInRange [inRangeEqn]] []
     return [inst]
   else
@@ -492,6 +498,7 @@ derRead mctx 0 lhs cs eread = do
   let
     loc = getSLoc eread
     iReadPrec = mkIdentSLoc loc "readPrec"
+    eReadPrec = EVar (mkBuiltin loc "readPrec")
     iReadList = mkIdentSLoc loc "readList"
     iReadListPrec = mkIdentSLoc loc "readListPrec"
     eReadListDefault = EVar (mkBuiltin loc "readListDefault")
@@ -503,8 +510,8 @@ derRead mctx 0 lhs cs eread = do
     eExpectIdent s = eAppI iExpectP (eAppI (mkBuiltin loc "Ident") (ELit loc (LStr s)))
     eExpectPunc s = eAppI iExpectP (eAppI (mkBuiltin loc "Punc") (ELit loc (LStr s)))
     eExpectSymbol s = eAppI iExpectP (eAppI (mkBuiltin loc "Symbol") (ELit loc (LStr s)))
-    eReadField = eAppI (mkBuiltin loc "step") (EVar iReadPrec)
-    eReadNamedField name = eAppI2 (mkBuiltin loc "readField") (ELit loc (LStr name)) (eAppI (mkBuiltin loc "reset") (EVar iReadPrec))
+    eReadField = eAppI (mkBuiltin loc "step") eReadPrec
+    eReadNamedField name = eAppI2 (mkBuiltin loc "readField") (ELit loc (LStr name)) (eAppI (mkBuiltin loc "reset") eReadPrec)
     eReturn = eAppI (mkBuiltin loc "return")
     ePfail = EVar (mkBuiltin loc "pfail")
     readConstr c@(Constr _ _ ident isInfix fields) =

--- a/tests/DerivingBuiltin.hs
+++ b/tests/DerivingBuiltin.hs
@@ -1,0 +1,23 @@
+module DerivingBuiltin (main) where
+
+import Prelude (Bounded, Enum, Eq, Foldable, Functor, Ord, Int, Read, Show, Traversable)
+import Data.Data (Data)
+import Data.Ix (Ix)
+import Data.Typeable (Typeable)
+
+data T a b c = A a | B b | C a Int | D
+    deriving (Bounded, {-Data,-} Eq, Ord, Read, Show, Typeable)
+
+data Rec a = R { x :: a, y :: Int }
+  deriving (Bounded, Data, Eq, Ord, Read, Show, Typeable)
+
+data E = X | Y | Z
+    deriving (Bounded, Data, Enum, Eq, Ix, Ord, Read, Show, Typeable)
+
+data U a = U1 | U2 Int | U3 a | U4 a Int (a, a) | U5 [U a]
+    deriving (Functor, Foldable, Traversable)
+
+data V a = V a a a
+    deriving (Bounded, Data, Eq, Ix, Ord, Read, Show, Typeable)
+
+main = main

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -121,6 +121,7 @@ test:
 	$(TMHS) Unboxed    && $(EVAL) > Unboxed.out    && diff Unboxed.ref Unboxed.out
 	$(TMHS) LazyST     && $(EVAL) > LazyST.out     && diff LazyST.ref LazyST.out
 	$(TMHS) Errno      && $(EVAL) > Errno.out      && diff Errno.ref Errno.out
+	$(TMHS) DerivingBuiltin
 
 testforimp:
 	$(TMHS) ForeignC -of.exe && ./f.exe > ForeignC.out && diff ForeignC.ref ForeignC.out


### PR DESCRIPTION
Some derivers didn't use builtin identifiers where they should have and some used builtin identifiers that were missing from `Mhs.Builtin`. Add a test to ensure that deriving works even if only the typeclasses are in scope.

Deriving `Data` for `data T a b c = A a | B b | C a Int | D` doesn't work, because of an unsatisfied `Typeable c` constraint. GHC also requires a `Typeable c` constraint and adds it in the derived instance. I don't understand why it's needed in the first place, though.