### PR TITLE
Fix `Data` deriving header

### DIFF
--- a/src/MicroHs/Deriving.hs
+++ b/src/MicroHs/Deriving.hs
@@ -213,8 +213,11 @@ conFieldTys (Constr _ _ _ _ as) = getFieldTys as
 -- will get context  (Eq a, Eq (a, Int))
 -- Used for regular deriving, not standalone.
 mkHdr :: StandM -> LHS -> [Constr] -> EConstraint -> T EConstraint
-mkHdr (Just (ctx, _)) _ _ _ = return ctx
-mkHdr _ lhs@(_, iks) cs cls = do
+mkHdr mctx lhs cs cls = mkHdrWithTyVarConstraint mctx lhs cs cls Nothing
+
+mkHdrWithTyVarConstraint :: StandM -> LHS -> [Constr] -> EConstraint -> Maybe EConstraint -> T EConstraint
+mkHdrWithTyVarConstraint (Just (ctx, _)) _ _ _ _ = return ctx
+mkHdrWithTyVarConstraint _ lhs@(_, iks) cs cls tyVarConstraint = do
   ty <- mkLhsTy 0 lhs
   let ctys :: [EType]  -- All top level types used by the constructors.
       ctys = nubBy eqEType [ tt
@@ -223,9 +226,11 @@ mkHdr _ lhs@(_, iks) cs cls = do
                            , not (ty `eqEType` tt)
                            , not $ null $ freeTyVars [tt] \\ map idKindIdent evs
                            ]
+      tyVars = map (EVar . idKindIdent) iks  -- type variables in type definition
       iks' = map (`IdKind` EVar dummyIdent) (freeTyVars [cls])  -- free type variables in the derived class
---  traceM $ "mkHdr: " ++ show (cls, iks')
-  pure $ eForall (iks' ++ iks) $ addConstraints (map (tApp cls) ctys) $ tApp cls ty
+      tyVarConstraints = maybe [] (\c -> map (tApp c) tyVars) tyVarConstraint
+--  traceM $ "mkHdrWithTyVarConstraints: " ++ show (cls, iks')
+  pure $ eForall (iks' ++ iks) $ addConstraints (map (tApp cls) ctys ++ tyVarConstraints) $ tApp cls ty
 
 -- instance header for Functor, Foldable, Traversable
 mkHdr1 :: StandM -> LHS -> [Constr] -> EConstraint -> T EConstraint
@@ -258,15 +263,6 @@ mkHdr1 _ lhs@(_, iks) cs cls = do
                       tts -> tt : tts
               _ -> []
   pure $ eForall (init iks) $ addConstraints (map (tApp cls) ctys) $ tApp cls ty'
-
--- Used for Data.  Just propagate the constraint to all type variables.
-mkHdrData :: StandM -> LHS -> [Constr] -> EConstraint -> T EConstraint
-mkHdrData (Just (ctx, _)) _ _ _ = return ctx
-mkHdrData _ lhs@(_, iks) _cs cls = do
-  ty <- mkLhsTy 0 lhs
-  let ctx = map (tApp cls . EVar . idKindIdent) iks
---  traceM $ "mkHdrData: " ++ show (cls, iks)
-  pure $ eForall iks $ addConstraints ctx $ tApp cls ty
 
 -- Used for regular deriving, not standalone.
 mkLhsTy :: Int -> LHS -> T EType
@@ -552,16 +548,18 @@ derRead _ _ lhs _ e = cannotDerive lhs e
 --  data T a = A
 derData :: Deriver
 derData mctx _ lhs@(utyname, vks) cs edata = do
-  hdr <- mkHdrData mctx lhs cs edata
-  mn <- getDefModuleName mctx
   let
-    tyname = qualIdent mn utyname
     loc = getSLoc edata
     mkB = mkBuiltin loc
     mkI = mkIdentSLoc loc
     lit = ELit loc
     str = lit . LStr . unIdentPar
     eList = EListish . LList
+    etyp = EVar (mkI nameDataTypeableTypeable)
+  hdr <- mkHdrWithTyVarConstraint mctx lhs cs edata (Just etyp)
+  mn <- getDefModuleName mctx
+  let
+    tyname = qualIdent mn utyname
     iMkDataType = mkB "mkDataType"
     iMkConstrTag = mkB "mkConstrTag"
     iConstrIndex = mkB "constrIndex"

--- a/tests/DerivingBuiltin.hs
+++ b/tests/DerivingBuiltin.hs
@@ -6,7 +6,7 @@ import Data.Ix (Ix)
 import Data.Typeable (Typeable)
 
 data T a b c = A a | B b | C a Int | D
-    deriving (Bounded, {-Data,-} Eq, Ord, Read, Show, Typeable)
+    deriving (Bounded, Data, Eq, Ord, Read, Show, Typeable)
 
 data Rec a = R { x :: a, y :: Int }
   deriving (Bounded, Data, Eq, Ord, Read, Show, Typeable)
@@ -19,5 +19,11 @@ data U a = U1 | U2 Int | U3 a | U4 a Int (a, a) | U5 [U a]
 
 data V a = V a a a
     deriving (Bounded, Data, Eq, Ix, Ord, Read, Show, Typeable)
+
+data These1 f g a
+    = This1 (f a)
+    | That1 (g a)
+    | These1 (f a) (g a)
+  deriving (Functor, Foldable, Traversable, Typeable, Data)
 
 main = main


### PR DESCRIPTION
This is the proper fix for https://github.com/augustss/MicroHs/issues/461. `These1` (see added test) requires `Data (f a)` and `Data (g a)` constraints, which are not implied by `(Data f, Data g, Data a)`. Additionally, if a type variable isn't used as a field type, it only needs a `Typeable` constraint.