### PR TITLE
move lzma include

### DIFF
--- a/src/runtime/lzma.h
+++ b/src/runtime/lzma.h
@@ -1728,13 +1728,11 @@ BoolInt CPU_IsSupported_AES(void)
 
 #else // __APPLE__
 
-#include <sys/auxv.h>
-
 // Don't use asm/hwcap.h, it does not seem to exist on all platforms.
 // #define USE_HWCAP
 
 #ifdef USE_HWCAP
-
+#include <sys/auxv.h>
 #include <asm/hwcap.h>
 
 #define MY_HWCAP_CHECK_FUNC_2(name1, name2)                     \


### PR DESCRIPTION
On my MCU there is no `sys/auxv.h`, so compilation fails. By moving the `include` to only be included if it is needed (if my understanding of what it does and where it is used is correct), my board compiles just fine with `USE_HWCAP` undefined.