### PR TITLE
fix: store `ByteString` literals as raw binary blobs instead of quoted text

### DIFF
--- a/src/MicroHs/ExpPrint.hs
+++ b/src/MicroHs/ExpPrint.hs
@@ -3,6 +3,7 @@ module MicroHs.ExpPrint(toStringCMdl, toStringP, encodeString, combVersion, remo
 import qualified Prelude(); import MHSPrelude
 import qualified Data.ByteString.Char8 as BS
 import Data.Char(ord, chr)
+import Data.List(nub)
 import qualified MicroHs.IdentMap as M
 import Data.Maybe
 import MicroHs.Desugar(LDef)
@@ -76,20 +77,55 @@ renumberCMdl (ds, emain) =
   in
     (fexps', (checkDupInstances res, substv emain))
 
+collectBlobs :: Exp -> [BS.ByteString]
+collectBlobs (App f a) = collectBlobs f ++ collectBlobs a
+collectBlobs (Lam _ e) = collectBlobs e
+collectBlobs (Lit (LStr s)) | length s > 1 = [BS.pack (utf8encode s)]
+collectBlobs (Lit (LBStr s)) = [s]
+collectBlobs _ = []
+
+type BlobMap = [(BS.ByteString, Int)]
+
+lookupBlob :: BlobMap -> BS.ByteString -> Int
+lookupBlob bm s = case lookup s bm of
+  Just i -> i
+  Nothing -> error "toStringPBlob: blob not in map"
+
+toStringPBlob :: BlobMap -> Exp -> (String -> String)
+toStringPBlob bm ae = case ae of
+  Var x   -> (showIdent x ++) . (' ' :)
+  Lit (LStr s) ->
+    if length s > 1 then
+      toStringPBlob bm (App (Lit (LPrim "fromUTF8")) (Lit (LBStr (BS.pack (utf8encode s)))))
+    else
+      toStringP (encodeString s)
+  Lit (LBStr s) -> ("$" ++) . (show (lookupBlob bm s) ++) . (' ' :)
+  Lit (LInteger _) -> undefined
+  Lit (LRat _) -> undefined
+  Lit (LTick s) -> ('!':) . (quoteString s ++) . (' ' :)
+  Lit l -> (showLit l ++) . (' ' :)
+  Lam _ _ -> undefined
+  App f a -> toStringPBlob bm f . toStringPBlob bm a . ("@" ++)
+
 -- The argument is all definitions and the main expression.
--- The result is the program as a string.
-toStringCMdl :: CMdl -> String
+-- The result is the program as a string and a list of binary blobs.
+toStringCMdl :: CMdl -> (String, [BS.ByteString])
 toStringCMdl (ds, emain) =
   let
+    unwrapFE e = case getForExp e of Just (e', _) -> e'; Nothing -> e
+    allExps = emain : map (unwrapFE . snd) ds
+    blobs = nub (concatMap collectBlobs allExps)
+    bm = zip blobs [(0::Int)..]
+
     def :: (Ident, Exp) -> (String -> String) -> (String -> String)
     def (i, e) r | Just (e', _) <- getForExp e = def (i, e') r
     def (i, e) r =
-      ("A " ++) . toStringP e . ((":" ++ showIdent i ++  " @\n") ++) . r . ("@" ++)
+      ("A " ++) . toStringPBlob bm e . ((":" ++ showIdent i ++  " @\n") ++) . r . ("@" ++)
 
     res :: String -> String
-    res = foldr def (toStringP emain) ds
+    res = foldr def (toStringPBlob bm emain) ds
 
-  in combVersion ++ show (length ds) ++ "\n" ++ res " }"
+  in (combVersion ++ show (length ds) ++ "\n" ++ res " }", blobs)
 
 checkDupInstances :: [LDef] -> [LDef]
 checkDupInstances ds =

--- a/src/MicroHs/Main.hs
+++ b/src/MicroHs/Main.hs
@@ -340,7 +340,7 @@ mainCompile flags mn = do
     mainName = qualIdent rmn (mkIdent "main")
     cmdl = (allDefs, if noLink flags then Lit (LInt 0) else Var mainName)
     (forExps, outCMdl@(outDefs, _)) = renumberCMdl cmdl
-    outData = toStringCMdl outCMdl
+    (outData, outBlobs) = toStringCMdl outCMdl
     numOutDefs = length outData
     numDefs = length allDefs
   when (verbosityGT flags 0) $
@@ -377,7 +377,7 @@ mainCompile flags mn = do
     let embedded = concatMap packageModules (getEmbedPkgs cash)
     let (cFFI, hFFI) = makeFFI flags forExps embedded
                                (outDefs : map (packageDefs . snd) embedPkg)
-        cCode = "#include \"mhsffi.h\"\n" ++ makeCArray flags outData ++ cFFI
+        cCode = "#include \"mhsffi.h\"\n" ++ makeCArray flags outBlobs outData ++ cFFI
 
     let outFile = output flags
     -- Generate stub file for 'foreign export'

--- a/src/MicroHs/MakeCArray.hs
+++ b/src/MicroHs/MakeCArray.hs
@@ -3,6 +3,7 @@
 module MicroHs.MakeCArray(makeCArray) where
 import qualified Prelude(); import MHSPrelude
 import Data.Char
+import qualified Data.ByteString as BS
 import MicroHs.Flags
 import qualified System.Compress as C
 
@@ -15,12 +16,17 @@ chunkify n xs =
 showChunk :: [Char] -> String
 showChunk = concatMap (\ c -> show (ord c) ++ ",")
 
-makeCArray :: Flags -> String -> String
-makeCArray flags file =
-  if compress flags then
-    makeCArray' ('z' : C.compress file)  -- stick a 'z' in front to indicate compressed
-  else
-    makeCArray' file
+showBlobChunk :: BS.ByteString -> String
+showBlobChunk bs = concatMap (\ b -> show b ++ ",") (BS.unpack bs)
+
+makeCArray :: Flags -> [BS.ByteString] -> String -> String
+makeCArray flags blobs file =
+  let fileCArray =
+        if compress flags then
+          makeCArray' ('z' : C.compress file)
+        else
+          makeCArray' file
+  in  fileCArray <> makeBlobArray blobs
 
 makeCArray' :: String -> String
 makeCArray' file =
@@ -31,3 +37,27 @@ makeCArray' file =
                  "const unsigned char *combexpr = data;",
                  "const int combexprlen = " ++ show (length file) ++ ";"
                 ]
+
+makeBlobArray :: [BS.ByteString] -> String
+makeBlobArray [] =
+  unlines ["const unsigned char *blobptrs = 0;",
+           "const int *bloboffs = 0;",
+           "const int blobcount = 0;"]
+makeBlobArray blobs =
+  let offsets = scanl (+) 0 (map BS.length blobs)
+      allBytes = BS.concat blobs
+      chunks = chunkifyBS 20 allBytes
+  in  unlines $ ["static const unsigned char blobdata[] = {"] ++
+                map showBlobChunk chunks ++
+                ["};",
+                 "static const int blob_offsets[] = {" ++ concatMap (\ o -> show o ++ ",") offsets ++ "};",
+                 "const unsigned char *blobptrs = blobdata;",
+                 "const int *bloboffs = blob_offsets;",
+                 "const int blobcount = " ++ show (length blobs) ++ ";"
+                ]
+
+chunkifyBS :: Int -> BS.ByteString -> [BS.ByteString]
+chunkifyBS _ bs | BS.null bs = []
+chunkifyBS n bs =
+  let (as, bbs) = BS.splitAt n bs
+  in  as : chunkifyBS n bbs

--- a/src/runtime/comb.c
+++ b/src/runtime/comb.c
@@ -2,3 +2,6 @@ unsigned char *combexpr = 0;
 int combexprlen = 0;
 struct ffi_entry *xffi_table = 0;
 struct ffe_entry *xffe_table = 0;
+const unsigned char *blobptrs = 0;
+const int *bloboffs = 0;
+const int blobcount = 0;

--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -139,6 +139,10 @@ int num_ffi;
 
 #define VERSION "v8.3\n"
 
+extern const unsigned char *blobptrs;
+extern const int *bloboffs;
+extern const int blobcount;
+
 #define PRIvalue PRIdPTR
 #define PRIuvalue PRIuPTR
 typedef uintptr_t heapoffs_t;   /* Heap offsets */
@@ -3833,6 +3837,22 @@ parse(BFILE *f)
         ERR1("unknown funptr '%s'", buf);
       }
       break;
+    case '$':
+      /* Binary blob reference: $N, points into static memory */
+      {
+        int idx = (int)parse_int(f);
+        if (idx < 0 || idx >= blobcount)
+          ERR1("bad blob index %d", idx);
+        struct bytestring bs;
+        bs.size = bloboffs[idx + 1] - bloboffs[idx];
+        bs.string = (uint8_t *)(blobptrs + bloboffs[idx]);
+        NODEPTR n = alloc_node(T_FORPTR);
+        struct forptr *fp = mkForPtr(bs);
+        FORPTR(n) = fp;
+        fp->finalizer->fptype = FP_BSTR;
+        PUSH(n);
+        break;
+      }
     default:
       buf[0] = c;
       /* A primitive, keep getting char's until end */

--- a/src/runtime/mhseval.c
+++ b/src/runtime/mhseval.c
@@ -9,6 +9,12 @@
 const uint8_t *combexpr = NULL;
 // eval.c expects: extern const int combexprlen;
 const int combexprlen = 0;
+// eval.c expects: extern const unsigned char *blobptrs;
+const unsigned char *blobptrs = NULL;
+// eval.c expects: extern const int *bloboffs;
+const int *bloboffs = NULL;
+// eval.c expects: extern const int blobcount;
+const int blobcount = 0;
 
 #include "eval.c"
 


### PR DESCRIPTION
When embedding packages (e.g. `--embed-packages base`), the raw .pkg bytes were encoded through `quoteString()` which expands each byte to 1-2 printable chars.  For binary data this causes ~1.6x expansion (68KB bloat for `base`).

Fix: add a `$N` blob reference opcode to the combinator format.  `ByteString` literals are collected during serialization and stored in a separate C array (`blobdata[]`) as raw bytes.  The runtime parses `$N` references and creates BSTR nodes pointing directly into static memory (no allocation, no freeing).

  | Metric              | Before       | After                         |
  | ------------------- | ------------ | ----------------------------- |
  | mhs (no embed)      |   463,280 B  |   461,456 B                   |
  | mhs + base (embed)  | 1,337,808 B  | 1,268,368 B                   |
  | base.pkg            |   806,183 B  |   806,183 B                   |
  | Bloat               |    68,345 B  |       729 B (98.9% reduction) |