### PR TITLE
fix buggy interaction between mvars and exceptions

### DIFF
--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -1357,7 +1357,19 @@ check_thrown(bool intr)
   if (thread_trace)
     printf("check_thrown: exn for %d\n", (int)runq.mq_head->mt_id);
 #endif  /* THREAD_DEBUG */
-  NODEPTR exn = take_mvar(false, runq.mq_head->mt_exn); /* get the exception */
+  /* Take the exception directly from the exception MVar, rather than reading it
+   * from the threads own mt_mval. The thread may have been woken up by a different
+   * MVar, but might not yet have consumed that value.
+   */
+  struct mvar *exnmv = runq.mq_head->mt_exn;
+  NODEPTR exn = exnmv->mv_data;
+  exnmv->mv_data = NIL;
+
+  /* Do we need to do this? What if a second throwTo is blocked? Let that thread proceed. */
+  struct mthread *waiter = remove_q_head(&exnmv->mv_takeput);
+  if (waiter)
+    add_runq_tail(waiter);
+
   raise_exn(exn);
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -109,6 +109,7 @@ test:
 	$(TMHS) Delay      && $(EVAL) > Delay.out      && diff Delay.ref Delay.out
 	$(TMHS) ThrSt      && $(EVAL) > ThrSt.out      && diff ThrSt.ref ThrSt.out
 	$(TMHS) Throw      && $(EVAL) > Throw.out      && diff Throw.ref Throw.out
+	$(TMHS) ThrowMVar  && $(EVAL) > ThrowMVar.out  && diff ThrowMVar.ref ThrowMVar.out
 	$(TMHS) RtsExn     && $(EVAL) > RtsExn.out     && diff RtsExn.ref RtsExn.out
 	$(TMHS) Mask       && $(EVAL) > Mask.out       && diff Mask.ref Mask.out
 	$(TMHS) EmptyData  && $(EVAL) > EmptyData.out  && diff EmptyData.ref EmptyData.out

--- a/tests/ThrowMVar.hs
+++ b/tests/ThrowMVar.hs
@@ -1,0 +1,17 @@
+module ThrowMVar where
+import Control.Concurrent
+import System.Exit (ExitCode(..))
+
+main :: IO ()
+main = do
+  mainTid <- myThreadId
+  sig <- newEmptyMVar
+
+  _ <- forkIO $ do
+    putMVar sig ()              -- wake main: () parked in main's mt_mval
+    throwTo mainTid ExitSuccess -- real exception parked in main's mt_exn
+
+  () <- takeMVar sig
+
+  -- This is not printed, since the exception has been delivered
+  putStrLn "BUG NOT TRIGGERED"


### PR DESCRIPTION
Fix a race condition in the MVar wakeup path.

The `mt_mval` field serves as a single slot for passing a value directly to a thread blocked on an MVar, bypassing the normal MVar machinery on wakeup (presumably as an efficiency optimisation?).

Asynchronous exceptions are implemented internally using MVars. This creates a race whereby if a thread is blocked on an MVar and (1) another thread writes to it, triggering a wakeup via `mt_mval`, and (2) a third thread (or the same one) concurrently delivers an async exception to the blocked thread before it has had a chance to handle the wakeup, both the MVar write and the exception machinery will attempt to write to `mt_mval` simultaneously. The result is a crash, unless the MVar happened to contain a `String`, in which case the corruption may go undetected (though it would still be a bug).

I add a test that without this proposed fix reliably crashes for me, with an `ERR: evalstring not Nil/Cons`, presumably from evaluating the exception string.

This patch fixes the race.