### PR TITLE
Explicit (*>) definition for IO

### DIFF
--- a/lib/System/IO/Internal.hs
+++ b/lib/System/IO/Internal.hs
@@ -121,6 +121,7 @@ instance Functor IO where
 
 instance Applicative IO where
   pure         = primReturn
+  (*>)         = primThen
   (<*>)        = ap
 
 instance Monad IO where


### PR DESCRIPTION
Using MircoHs v0.16.1.0, I made a test program that prints some data in a loop using something like
```haskell
main_crashes0 = for_ (cycle [0 .. 20]) \a -> do
 putStrLn $ show a
```
This worked for some time but after leaving it running it crashed with `ERR: stack overflow`. I then rewrote it using manual recursion which worked fine.
```haskell
 main_fine0 = let loop 20 = putStrLn (show 20) >> loop 0
                  loop i = putStrLn (show i) >> loop (succ i)
    in loop 0
```
This didn't have the issue (or i did not run it long enough).

After trying out different things I found these simpler examples:
```haskell
main_works1   = Control.Monad.mapM_     print [(0 :: Int) ..]
main_crashes1 = Data.Foldable.traverse_ print [(0 :: Int) ..]
```

You can even replace `[(0::Int) ..]` with `repeat (0::Int)`
```haskell
main_crashes2 = Data.Foldable.traverse_ print (repeat (0::Int))
```

This demonstrates that the difference between `Applicative` and `Monad` is important here.
```haskell
main_works3   = Data.Foldable.sequence_  (repeat (putStrLn "Test"))
main_crashes3 = Data.Foldable.sequenceA_ (repeat (putStrLn "Test"))
```

I believe the reason for this to be the usage of `*>` in `sequenceA_` which is defined differently to `>>` used in `sequence_`.
```haskell
-- lib/System/IO/Internal.hs

instance Applicative IO where
  pure         = primReturn
  (<*>)        = ap

instance Monad IO where
  (>>=)        = primBind
  (>>)         = primThen
  return       = primReturn
```

And together with definition of Applicative this creates some unnecessary computations.
```haskell
-- lib/Control/Applicative.hs
  a1 *> a2     = (id <$ a1) <*> a2
  a1 <* a2     = const <$> a1 <*> a2
  liftA2 f a b = f <$> a <*> b
```

I think it is best to add `(*>) = primThen` to the `Applicative IO` instance.
Using this the programs don't terminate.


```haskell
  -- not sure about this one
  a1 <* a2     = a1 `primBind` \ a -> a2 `primThen` primReturn a
```

Note: I did not think about test cases for this issue.