### PR TITLE
Add instance Monoid IO

### DIFF
--- a/lib/System/IO.hs
+++ b/lib/System/IO.hs
@@ -71,6 +71,12 @@ fixIO k = do
 instance MonadFix IO where
   mfix = fixIO
 
+instance Semigroup a => Semigroup (IO a) where
+  (<>) = liftA2 (<>)
+
+instance Monoid a => Monoid (IO a) where
+  mempty = pure mempty
+
 data Newline = LF | CRLF
   deriving (Eq, Ord, Show, Read)
 


### PR DESCRIPTION
This instance matches the one found in base.
It is useful when combined with `Monoid ((->) a)`:
```haskell
> (print <> (print.(+1))) 1
1
2
```
or to combine the result
```haskell
> fmap Sum readLn <> fmap Sum readLn >>= print . getSum
> 1
> 2
3
```

I put it in this file since it imports MiniPrelude (which depends on Monoid) and the file is about IO.