### PR TITLE
mhs.conf documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,8 @@ installmsg:
 	@echo '*    mcabal  - cabal for MicroHs'
 	@echo '*  Libraries:'
 	@echo '*    base (bytestring, deepseq, directory, hashable, text, stm)'
+	@echo '*  Configuration (in $(MDATA)):'
+	@echo '*    mhs.conf  – package path and build targets'
 	@echo '***************************************************'
 	@echo ''
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,14 @@ You can enter expressions to be evaluated, or top level definitions (including `
 Simple line editing is available.
 
 ## MHS as a cross compiler
-When `mhs` is built, targets.conf is generated. It will look something like this:
+When `mhs` is built, `mhs.conf` is generated with a number of predefined targets.
+It will look something like this:
 ```ini
-[default]
+[unix]
 cc = "cc"
-conf = "unix-64"
+ccflags = "-w -Wall -O3 "
+cclibs = " -lm"
+conf = "unix"
 ```
 
 You can add other targets to this file, changing which compiler command is used and which runtime is


### PR DESCRIPTION
It seems the targets have moved to `mhs.conf`.

I had to search for installed `mhs.conf` so I added it to the install message.