### PR TITLE
Fix LZMA guards

### DIFF
--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -7151,8 +7151,12 @@ MHS_INIT_ARGS(
     }
 #endif
     if (c == 'z') {
-      /* add LZ77 decompressor transducer */
+#if WANT_LZMA
+      /* add LZMA decompressor transducer */
       bf = add_lzma_decompressor(bf);
+#else
+      ERR("LZMA compression not supported");
+#endif
     } else {
       /* put it back, we need it */
       ungetb(c, bf);


### PR DESCRIPTION
I want to use `#define WANT_LZMA 0` on my MCU, as I don't care about compression in this case. However, this makes the build fail because there is one unguarded usage of the LZMA machinery.