### PR TITLE
Add casting functions to `Data.Float` and `Data.Double`

### DIFF
--- a/lib/Data/Double.hs
+++ b/lib/Data/Double.hs
@@ -1,6 +1,6 @@
 -- Copyright 2025 Lennart Augustsson
 -- See LICENSE file for full license.
-module Data.Double(Double, doubleToInt) where
+module Data.Double(Double, doubleToInt, castWord64ToDouble, castDoubleToWord64) where
 import qualified Prelude()              -- do not import Prelude
 import Primitives
 import Control.Error
@@ -207,3 +207,9 @@ encodeFloat64 mant expn = scaleFloat64 expn (fromInteger mant)
 
 doubleToInt :: Double -> Int
 doubleToInt = primDoubleToInt
+
+castWord64ToDouble :: Word64 -> Double
+castWord64ToDouble = primWord64ToDoubleRaw
+
+castDoubleToWord64 :: Double -> Word64
+castDoubleToWord64 = primWord64FromDoubleRaw

--- a/lib/Data/Float.hs
+++ b/lib/Data/Float.hs
@@ -1,6 +1,6 @@
 -- Copyright 2025 Lennart Augustsson
 -- See LICENSE file for full license.
-module Data.Float(Float, floatToDouble, doubleToFloat) where
+module Data.Float(Float, floatToDouble, doubleToFloat, castWord32ToFloat, castFloatToWord32) where
 import qualified Prelude()              -- do not import Prelude
 import Primitives
 import Control.Error
@@ -24,6 +24,7 @@ import Data.RealFloat
 import Data.RealFrac
 import Data.Num
 import Data.Word.Word
+import Data.Word.Word32
 import {-# SOURCE #-} Numeric.FormatFloat(showFloat)
 import Numeric.Show(showSignedNeg)
 import Text.Show
@@ -206,3 +207,9 @@ floatToDouble = primFloatToDouble
 
 doubleToFloat :: Double -> Float
 doubleToFloat = primDoubleToFloat
+
+castWord32ToFloat :: Word32 -> Float
+castWord32ToFloat w = primWordToFloatRaw (primUnsafeCoerce w) -- Safety: Word32 is a newtype over Word
+
+castFloatToWord32 :: Float -> Word32
+castFloatToWord32 f = primUnsafeCoerce (primWordFromFloatRaw f) -- Safety: Word32 is a newtype over Word


### PR DESCRIPTION
These have been added to GHC base in https://github.com/haskell/core-libraries-committee/issues/378.