### PR TITLE
Change the compiler to accept an optional argument for the cache path

### DIFF
--- a/src/MicroHs/Compile.hs
+++ b/src/MicroHs/Compile.hs
@@ -56,9 +56,6 @@ import Text.PrettyPrint.HughesPJLiteClass(prettyShow)
 mhsVersion :: String
 mhsVersion = showVersion version
 
-mhsCacheName :: FilePath
-mhsCacheName = ".mhscache"
-
 type Time = Int
 
 type CM a = StateIO Cache a
@@ -88,21 +85,21 @@ loadEmbedded flags ach =
 getCached :: Flags -> IO Cache
 getCached flags | not (readCache flags) = return emptyCache
 getCached flags = do
-  mcash <- loadCached mhsCacheName
+  mcash <- loadCached (cacheName flags)
   case mcash of
     Nothing ->
       return emptyCache
     Just cash -> do
       when (loading flags || verbosityGT flags 0) $
-        putStrLn $ "Loading saved cache " ++ show mhsCacheName
+        putStrLn $ "Loading saved cache " ++ show (cacheName flags)
       validateCache flags cash
 
 maybeSaveCache :: Flags -> Cache -> IO ()
 maybeSaveCache flags cash =
   when (writeCache flags) $ do
     when (verbosityGT flags 0) $
-      putStrLn $ "Saving cache " ++ show mhsCacheName
-    saveCache mhsCacheName cash
+      putStrLn $ "Saving cache " ++ show (cacheName flags)
+    saveCache (cacheName flags) cash
 
 -- Load the real modules for imported boot modules.
 -- Doing so can result in more boot imports, so we recurse.

--- a/src/MicroHs/Flags.hs
+++ b/src/MicroHs/Flags.hs
@@ -15,6 +15,7 @@ data Flags = Flags {
   speed      :: Bool,       -- show lines/s
   readCache  :: Bool,       -- read and use cache
   writeCache :: Bool,       -- generate cache
+  cacheName  :: FilePath,   -- file name for compilation cache
   useTicks   :: Bool,       -- emit ticks
   doCPP      :: Bool,       -- run ccphs on input files
   noCode     :: Bool,       -- don't generate code
@@ -59,6 +60,7 @@ defaultFlags = Flags {
   speed      = False,
   readCache  = False,
   writeCache = False,
+  cacheName  = ".mhscache",
   useTicks   = False,
   doCPP      = False,
   noCode     = False,

--- a/src/MicroHs/Main.hs
+++ b/src/MicroHs/Main.hs
@@ -83,7 +83,7 @@ mHSPKG :: String
 mHSPKG = "MHSPKG"
 
 usage :: String
-usage = "Usage: mhs [-h|?] [--help] [--version] [--numeric-version] [-v] [-q] [-l] [-s] [-r] [-C[R|W]] [-XCPP] [-DDEF] [-IPATH] [-T] [-z] [-b64] [-iPATH] [-oFILE] [-a[PATH]] [-L[FILE|PKG]] [-PPKG] [-Q PKG [DIR]] [-pFILE] [-tTARGET] [-optc OPTION] [-optl OPTION] [--interactive] [-eEXPR] [-ECMD] [-ddump-PASS] [--embed-packages PKG:...] [--embed-ffis PKG:...] [MODULENAME...|FILE]"
+usage = "Usage: mhs [-h|?] [--help] [--version] [--numeric-version] [-v] [-q] [-l] [-s] [-r] [-C[R|W][PATH]] [-XCPP] [-DDEF] [-IPATH] [-T] [-z] [-b64] [-iPATH] [-oFILE] [-a[PATH]] [-L[FILE|PKG]] [-PPKG] [-Q PKG [DIR]] [-pFILE] [-tTARGET] [-optc OPTION] [-optl OPTION] [--interactive] [-eEXPR] [-ECMD] [-ddump-PASS] [--embed-packages PKG:...] [--embed-ffis PKG:...] [MODULENAME...|FILE]"
 
 longUsage :: String
 longUsage = usage ++ "\nOptions:\n" ++ details
@@ -93,9 +93,9 @@ longUsage = usage ++ "\nOptions:\n" ++ details
       \-a                 Clear package search path\n\
       \-aPATH             Add PATH to package search path\n\
       \-b64               Base64 encode the combinator code\n\
-      \-C                 Read and write compilation cache\n\
-      \-CR                Read compilation cache\n\
-      \-CW                Write compilation cache\n\
+      \-C[PATH]           Read and write compilation cache, optionally at PATH (default .mhscache)\n\
+      \-CR[PATH]          Read compilation cache, optionally from PATH\n\
+      \-CW[PATH]          Write compilation cache, optionally to PATH\n\
       \-c                 Do not generate executable\n\
       \-Dxxx              Pass -Dxxx to cpphs\n\
       \-ddump-PASS        Debug, print AST after PASS\n\
@@ -153,6 +153,9 @@ decodeArgs f mdls (arg:args) =
     "-CR"       -> decodeArgs f{readCache = True} mdls args
     "-CW"       -> decodeArgs f{writeCache = True} mdls args
     "-C"        -> decodeArgs f{readCache = True, writeCache = True} mdls args
+    '-':'C':'R':s@(_:_) -> decodeArgs f{readCache = True, cacheName = s} mdls args
+    '-':'C':'W':s@(_:_) -> decodeArgs f{writeCache = True, cacheName = s} mdls args
+    '-':'C':s@(_:_)     -> decodeArgs f{readCache = True, writeCache = True, cacheName = s} mdls args
     "-T"        -> decodeArgs f{useTicks = True} mdls args
     "-XCPP"     -> decodeArgs f{doCPP = True} mdls args
     "-z"        -> decodeArgs f{compress = True} mdls args


### PR DESCRIPTION
Possible fix for #510 Instead of e.g `-CW`, a use can now write `-CWpath`

If we change the usage string to be based on explicit concatenation we can refer to a top-level default name rather than duplicating the default here, but I didn't do that for now.