### PR TITLE
WANT_FLOAT32 bug: if set to 0, there is an unconditional use

### DIFF
--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -7792,7 +7792,9 @@ from_t mhs_mpz_cmp(int s) { return mhs_from_Int(s, 2, mpz_cmp(mhs_to_Ptr(s, 0), 
 #if WANT_FLOAT64
 from_t mhs_mpz_get_d(int s) { return mhs_from_Double(s, 1, mpz_get_d(mhs_to_Ptr(s, 0))); }
 #endif  /* WANT_FLOAT64 */
+#if WANT_FLOAT32
 from_t mhs_mpz_get_f(int s) { return mhs_from_Float(s, 1, (float)mpz_get_d(mhs_to_Ptr(s, 0))); }
+#endif  /* WANT_FLOAT32 */
 from_t mhs_mpz_get_si(int s) { return mhs_from_Int(s, 1, mpz_get_si_(mhs_to_Ptr(s, 0))); }
 from_t mhs_mpz_init_set_si(int s) { mpz_init_set_si(mhs_to_Ptr(s, 0), mhs_to_Int(s, 1)); return mhs_from_Unit(s, 2); }
 from_t mhs_mpz_init_set_ui(int s) { mpz_init_set_ui(mhs_to_Ptr(s, 0), mhs_to_Word(s, 1)); return mhs_from_Unit(s, 2); }
@@ -8060,7 +8062,9 @@ const struct ffi_entry ffi_table[] = {
   { "mpz_tdiv_qr", 4, mhs_mpz_tdiv_qr},
   { "mpz_tstbit", 2, mhs_mpz_tstbit},
   { "mpz_xor", 3, mhs_mpz_xor},
+#if WANT_FLOAT32
   { "mpz_get_f", 1, mhs_mpz_get_f},
+#endif  /* WANT_FLOAT32 */
 #if WANT_INT64
   { "mpz_init_set_si64", 2, mhs_mpz_init_set_si64},
   { "mpz_init_set_ui64", 2, mhs_mpz_init_set_ui64},


### PR DESCRIPTION
`mhs_from_Float` only exists if `#define WANT_FLOAT32 1`, but is used unconditionally by `mhs_mpz_get_f`. The fix is to guard the usage as well, mirroring how `mhs_mpz_get_d` is implemented.

I have a script that tries to find configurations that break the build, even though they shouldn't. I rerun it as soon as the fixes land, so I am afraid I might open several of these little PRs.