### PR TITLE
benchmarking machinery

### DIFF
--- a/benchmarks/Loads/ExprEval.hs
+++ b/benchmarks/Loads/ExprEval.hs
@@ -1,0 +1,34 @@
+module Loads.ExprEval(main) where
+
+-- A tiny expression AST, generated as a large, deterministic, roughly
+-- balanced tree and then evaluated. Stresses tree-shaped allocation and
+-- non-tail-recursive pattern matching.
+data Expr
+  = Lit !Int
+  | Add Expr Expr
+  | Sub Expr Expr
+  | Mul Expr Expr
+
+build :: Int -> Int -> Expr
+build 0 seed = Lit (seed `rem` 17 - 8)
+build d seed =
+  case seed `rem` (3 :: Int) of
+    0 -> Add (build (d - 1) (seed * 2 + 1)) (build (d - 1) (seed * 2 + 2))
+    1 -> Sub (build (d - 1) (seed * 2 + 1)) (build (d - 1) (seed * 2 + 2))
+    _ -> Mul (build (d - 1) (seed * 2 + 1)) (build (d - 1) (seed * 2 + 2))
+
+-- we do mod m to not overflow, which is an error in mhs
+m :: Int
+m = 1000003
+
+eval :: Expr -> Int
+eval (Lit n)   = n `mod` m
+eval (Add a b) = (eval a + eval b) `mod` m
+eval (Sub a b) = (eval a - eval b) `mod` m
+eval (Mul a b) = (eval a * eval b) `mod` m
+
+main :: IO ()
+main = do
+  let depth = 19
+      tree  = build depth 1
+  print (eval tree)

--- a/benchmarks/Loads/FibInt.hs
+++ b/benchmarks/Loads/FibInt.hs
@@ -1,0 +1,13 @@
+module Loads.FibInt(main) where
+
+-- Same naive doubly-recursive Fibonacci as Loads.FibInteger, but on the
+-- fixed-width Int type instead of Integer
+fib :: Int -> Int
+fib 0 = 0
+fib 1 = 1
+fib n = fib (n - 1) + fib (n - 2)
+
+main :: IO ()
+main = do
+  let n = 33
+  print (fib n)

--- a/benchmarks/Loads/FibInteger.hs
+++ b/benchmarks/Loads/FibInteger.hs
@@ -1,0 +1,14 @@
+module Loads.FibInteger(main) where
+
+-- Naive doubly-recursive Fibonacci on Integer. Exponential call count with
+-- tiny-magnitude arithmetic, mostly stresses call/reduction
+-- throughput
+fib :: Integer -> Integer
+fib 0 = 0
+fib 1 = 1
+fib n = fib (n - 1) + fib (n - 2)
+
+main :: IO ()
+main = do
+  let n = 33
+  print (fib n)

--- a/benchmarks/Loads/FibTail.hs
+++ b/benchmarks/Loads/FibTail.hs
@@ -1,0 +1,15 @@
+module Loads.FibTail(main) where
+
+-- Strictly tail-recursive Fibonacci via an accumulator pair, with results
+-- kept small by a modulus.
+modulus :: Int
+modulus = 1000000007
+
+fib :: Int -> Int -> Int -> Int
+fib !a !_ 0 = a
+fib !a !b n = fib b ((a + b) `rem` modulus) (n - 1)
+
+main :: IO ()
+main = do
+  let n = 20000000
+  print (fib 0 1 n)

--- a/benchmarks/Loads/ForkJoin.hs
+++ b/benchmarks/Loads/ForkJoin.hs
@@ -1,0 +1,23 @@
+module Loads.ForkJoin(main) where
+import Control.Concurrent
+
+-- Fork many green threads that each do a chunk of CPU work, then join on
+-- all of them via MVar. Exercises thread creation/scheduling/reap and MVar
+-- synchronization.
+work :: Int -> Int
+work = go 0
+  where
+    go !acc 0 = acc
+    go !acc k = go (acc + k) (k - 1)
+
+worker :: MVar Int -> Int -> IO ()
+worker result n = putMVar result (work n)
+
+main :: IO ()
+main = do
+  let numWorkers    = 50
+      workPerThread = 50000
+  mvars <- mapM (const newEmptyMVar) [1 .. numWorkers]
+  mapM_ (\m -> forkIO (worker m workPerThread)) mvars
+  results <- mapM takeMVar mvars
+  print (sum results)

--- a/benchmarks/Loads/ListFusion.hs
+++ b/benchmarks/Loads/ListFusion.hs
@@ -1,0 +1,10 @@
+module Loads.ListFusion(main) where
+
+-- Builds a list purely to immediately consume it: [1..n] is produced,
+-- filtered, mapped, and summed. With foldr/build-style deforestation this
+-- compiles down to a single allocation-free loop; without it, three full
+-- n-cons-cell lists get materialized and garbage-collected.
+main :: IO ()
+main = do
+  let n = 3000000
+  print (sum (map (+ 1) (filter even [1 .. n])))

--- a/benchmarks/Loads/MergeSort.hs
+++ b/benchmarks/Loads/MergeSort.hs
@@ -1,0 +1,36 @@
+module Loads.MergeSort(main) where
+import Data.List(foldl')
+
+-- Clanker-proposed deterministic PRNG so the benchmark needs no external
+-- dependency and is reproducible across runs/machines.
+lcg :: Int -> Int
+lcg x = (1103515245 * x + 12345) `mod` 2147483648
+
+genList :: Int -> Int -> [Int]
+genList _    0 = []
+genList seed n = seed : genList (lcg seed) (n - 1)
+
+merge :: [Int] -> [Int] -> [Int]
+merge [] ys = ys
+merge xs [] = xs
+merge xs@(x : xs') ys@(y : ys')
+  | x <= y    = x : merge xs' ys
+  | otherwise = y : merge xs ys'
+
+msort :: [Int] -> [Int]
+msort []  = []
+msort [x] = [x]
+msort xs  = merge (msort as) (msort bs)
+  where (as, bs) = splitAt (length xs `quot` 2) xs
+
+main :: IO ()
+main = do
+  let n      = 100000
+      xs     = genList 42 n
+      sorted = msort xs
+      -- Force the whole spine and payload, and confirm it's actually
+      -- sorted, without printing all n numbers.
+      (total, isSorted, _) =
+        foldl' (\ (!acc, !ok, !prev) x -> (acc + x, ok && x >= prev, x))
+               (0 :: Int, True, minBound :: Int) sorted
+  print (total, isSorted)

--- a/benchmarks/Loads/NFib.hs
+++ b/benchmarks/Loads/NFib.hs
@@ -1,0 +1,14 @@
+module Loads.NFib(main) where
+
+-- Classic combinator-reduction benchmark: deeply recursive, tiny-int
+-- arithmetic, no data structure allocation.
+nfib :: Int -> Int
+nfib n =
+  case n < 2 of
+    True  -> 1
+    False -> nfib (n - 1) + nfib (n - 2) + 1
+
+main :: IO ()
+main = do
+  let n = 33
+  print (nfib n)

--- a/benchmarks/Loads/NumericIntegration.hs
+++ b/benchmarks/Loads/NumericIntegration.hs
@@ -1,0 +1,13 @@
+module Loads.NumericIntegration(main) where
+
+-- Strict tail-recursive Double accumulation in a tight loop. Same shape as
+-- TightIntLoop, but over Double, so it isolates the floating-point
+-- add/box path instead of Int arithmetic.
+sumTo :: Double -> Int -> Double
+sumTo !acc 0 = acc
+sumTo !acc n = sumTo (acc + fromIntegral n) (n - 1)
+
+main :: IO ()
+main = do
+  let n = 5000000
+  print (sumTo 0.0 n)

--- a/benchmarks/Loads/PrimesSieve.hs
+++ b/benchmarks/Loads/PrimesSieve.hs
@@ -1,0 +1,14 @@
+module Loads.PrimesSieve(main) where
+
+-- The classic (deliberately naive) trial-division sieve built from nested
+-- lazy list filters. Heavy on list-cell allocation rather than raw arithmetic.
+primes :: [Int]
+primes = sieve [2 ..]
+  where
+    sieve (p : xs) = p : sieve [x | x <- xs, x `rem` p /= 0]
+    sieve []       = []
+
+main :: IO ()
+main = do
+  let n = 3000
+  print (primes !! (n - 1))

--- a/benchmarks/Loads/TightIntLoop.hs
+++ b/benchmarks/Loads/TightIntLoop.hs
@@ -1,0 +1,13 @@
+module Loads.TightIntLoop(main) where
+
+-- Strict tail-recursive Int accumulation. Stresses basic arithmetic
+-- dispatch and the boxing/unboxing path for Int, with essentially no
+-- allocation once the loop is running (presumably).
+sumTo :: Int -> Int -> Int
+sumTo !acc 0 = acc
+sumTo !acc n = sumTo (acc + n) (n - 1)
+
+main :: IO ()
+main = do
+  let n = 5000000
+  print (sumTo 0 n)

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,0 +1,35 @@
+# Build and run the benchmark suite.
+#
+#   make build          -- compile every benchmark + the harness
+#   make bench          -- build, then run the harness (writes benchmarks/results/run-<ts>.json)
+#   make bench RUNS=10  -- same, but run each benchmark's executable 10 times instead of the default 5
+#   make clean          -- remove compiled executables (keeps .hs/.out/results)
+#
+MHS      = bin/mhs
+MHSFLAGS = -ilib -ibenchmarks -CR
+RUNS     = 5
+
+BENCHMARKS = NFib TightIntLoop NumericIntegration FibInteger FibInt FibTail PrimesSieve MergeSort ExprEval ForkJoin ListFusion
+
+.PHONY: build bench clean cachelib
+
+# Each benchmark below is a separate mhs invocation, and every one of them
+# pulls in the base library. Priming ../.mhscache once up front
+# means the -CR in MHSFLAGS lets them all reuse that compiled base instead
+# of each recompiling it from scratch.
+cachelib:
+	cd .. && rm -f .mhscache && $(MHS) -ilib -CW AllOfLib
+
+build: cachelib $(BENCHMARKS:%=%.exe) BenchHarness.exe
+
+%.exe: Loads/%.hs
+	cd .. && $(MHS) $(MHSFLAGS) Loads.$* -o benchmarks/$@
+
+BenchHarness.exe: Util/BenchHarness.hs Util/RunStats.hs Util/Json.hs
+	cd .. && $(MHS) $(MHSFLAGS) Util.BenchHarness -o benchmarks/BenchHarness.exe
+
+bench: build
+	cd .. && benchmarks/BenchHarness.exe $(RUNS)
+
+clean:
+	rm -f *.exe

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,22 @@
+Simple benchmarking machinery to compare how a set of benchmarks performs when changes have been made to the runtime.
+
+Run `make build` to build the benchmarks. Run `make bench` to run them and collect their results. The results are written to `results/`, into a time-stamped JSON file.
+
+Each benchmark's executable is run 5 times by default (`make bench RUNS=10` to override). The report keeps every sample plus the min and median for the wall-clock fields (`total_time_secs`, `gc_time_secs`). The actuall wall-clock times can be a bit noise, but other things like reductions and allocations numbers appear to be deterministic.
+
+- `Util/` - contains drivers and helpers
+  - `BenchmarkHarness.hs` -
+  - `Json.hs` - Defines a datatype for JSON, and a renderer.
+  - `RunStats.hs` - Defines a datatype to represent the output from `+RTS -v -RTS`, and implements a parser to construct it from said output.
+- `Loads/` - contains the actual programs that will be executed
+  - `ExprEval.hs` - Generates and evaluates a tree-shaped AST
+  - `FibInteger.hs` - Double-call fibonacco with `Integer`s.
+  - `FibInt.hs` -  Double-call fibonacci with `Int`, to compare with the `Integer` version.
+  - `FibTail.hs` - Fibonacci with tail-recursion, to see if it is optimized.
+  - `ForkJoin.hs` - Forks some green threads and joins them, to exercise green thread performance.
+  - `ListFusion.hs` - Builds a list via `[1..n]`, filters, maps, and sums it, to check how well producer/transformer/consumer list fusion (deforestation) works. (spoiler, there is no deforestation in mhs).
+  - `MergeSort.hs` - Classic mergesort of lists of numbers.
+  - `NFib.hs` - Counts the number of calls. I include this as it is a 'classic' benchmark.
+  - `NumericIntegration.hs` - Strict Double accumulation in a tight loop.
+  - `PrimeSieve.hs` - Prime counter, using nested lazy list filters.
+  - `TightIntLoop.hs` - Int accumulator, tail recursive.

--- a/benchmarks/Util/BenchHarness.hs
+++ b/benchmarks/Util/BenchHarness.hs
@@ -1,0 +1,231 @@
+-- Runs every benchmark's compiled executable multiple times, parses
+-- the stats with RunStats, and writes one JSON file per invocation
+-- to benchmarks/results/. Running it again writes a new, separate file
+-- (named by the run's timestamp).
+--
+-- Expects the benchmarks to already be built, and expects to be run from
+-- the repo root
+module Util.BenchHarness(main) where
+import Control.Exception(SomeException, catch)
+import Data.List(dropWhileEnd, minimumBy, sort)
+import Data.Char(isSpace)
+import Data.Ord(comparing)
+import Numeric(showFFloat)
+import System.Directory(createDirectoryIfMissing, doesFileExist, listDirectory)
+import System.Environment(getArgs)
+import System.Exit(exitFailure)
+import System.IO.TimeMilli(getTimeMilli)
+import System.Process(readProcess)
+import Text.Read(readMaybe)
+
+import Util.Json
+import Util.RunStats
+
+-- | The directory in which we place singular .hs-files, which
+-- each encode a benchmark
+benchmarkDirectory :: String
+benchmarkDirectory = "benchmarks/Loads/"
+
+-- | How many times to run each benchmark's executable
+defaultRuns :: Int
+defaultRuns = 5
+
+-- | Read the names of all benchmark programs in benchmarkDirectory
+readBenchmarkNames :: IO [String]
+readBenchmarkNames = do
+  files <- listDirectory benchmarkDirectory
+  return $ map (takeWhile ((/=) '.')) files
+
+main :: IO ()
+main = do
+  args <- getArgs
+  runs <- case args of
+    [s] | Just n <- readMaybe s, n > 0 -> return n
+    []                                 -> return defaultRuns
+    _                                  -> do
+      putStrLn "usage: BenchHarness.exe [runs]"
+      exitFailure
+
+  -- the time at which the benchmark runner was invoked, for
+  -- tagging the report
+  ts <- getTimeMilli
+
+  names <- readBenchmarkNames
+
+  -- meta-information for the report
+  commit <- getGitCommit
+  dirty  <- getGitDirty
+
+  -- run the benchmarks
+  entries <- mapM (runOne runs) names
+
+  let anyFail = any entryFailed entries
+      doc = JObject
+        [ ("timestamp_ms", jInt ts)
+        , ("git_commit", jMaybe jString commit)
+        , ("git_dirty", jMaybe JBool dirty)
+        , ("benchmarks", JArray (map entryJSON entries))
+        ]
+      path = "benchmarks/results/run-" ++ show ts ++ ".json"
+
+  -- write the report
+  createDirectoryIfMissing True "benchmarks/results"
+  writeFile path (renderJSON doc ++ "\n")
+
+  -- briefly output
+  mapM_ (putStrLn . describeEntry) entries
+  putStrLn ("wrote " ++ path)
+
+  if anyFail then exitFailure else return ()
+
+--------------------------------------------------------------------------
+
+-- | An entry for the benchmark report
+data Entry
+    -- ^ All went well; one RunStats per repeat (in run order), always
+    -- non-empty
+  = EntryOk String [RunStats]
+    -- ^ The entry was not built, for some reason
+  | EntryMissing String
+    -- ^ Entry existed and ran, but its output could not be parsed
+    -- I am not sure when this can happen, but there's a case for it none the less.
+  | EntryParseError String String
+
+-- | Does an entry represent a benchmark that could not be run?
+entryFailed :: Entry -> Bool
+entryFailed (EntryOk _ _) = False
+entryFailed _             = True
+
+-- | Turn an entry into a JSON object, for the report
+entryJSON :: Entry -> JSON
+entryJSON (EntryOk name stats)       = JObject [("name", jString name), ("ok", JBool True),  ("stats", statsJSON stats)]
+entryJSON (EntryMissing name)        = JObject [("name", jString name), ("ok", JBool False), ("error", jString "executable not built")]
+entryJSON (EntryParseError name err) = JObject [("name", jString name), ("ok", JBool False), ("error", jString err)]
+
+-- | Turn an entry into a brief one-line description
+describeEntry :: Entry -> String
+describeEntry (EntryOk name stats) =
+  let times = map rsTotalTimeSecs stats
+      rs    = fastest stats
+  in name ++ ": " ++ show (rsReductions rs) ++ " reductions, min " ++
+     showSecs (minimum times) ++ "s (median " ++ showSecs (median times) ++ "s, n=" ++ show (length stats) ++ "), " ++
+     show (rsGCs rs) ++ " GCs"
+describeEntry (EntryMissing name)       = name ++ ": FAIL (not built -- run 'make build' first)"
+describeEntry (EntryParseError name e)  = name ++ ": FAIL (" ++ e ++ ")"
+
+-- | Run a benchmark N times and collect its results. Stops at the first
+-- repeat whose output fails to parse.
+runOne :: Int -> String -> IO Entry
+runOne runs name = do
+  built <- doesFileExist exe
+  if not built then return (EntryMissing name) else go []
+  where
+    exe = "benchmarks/" ++ name ++ ".exe"
+    go acc
+      | length acc == runs = return (EntryOk name (reverse acc))
+      | otherwise = do
+          out <- readProcess exe ["+RTS", "-v", "-RTS"] ""
+          case parseRunStats out of
+            Left err -> return (EntryParseError name err)
+            Right rs -> go (rs : acc)
+
+-- | The repeat with the lowest total time
+fastest :: [RunStats] -> RunStats
+fastest = minimumBy (comparing rsTotalTimeSecs)
+
+showSecs :: Double -> String
+showSecs d = showFFloat (Just 3) d ""
+
+median :: [Double] -> Double
+median xs =
+  let sorted = sort xs
+      n      = length sorted
+  in if odd n
+     then sorted !! (n `div` 2)
+     else (sorted !! (n `div` 2 - 1) + sorted !! (n `div` 2)) / 2
+
+--------------------------------------------------------------------------
+-- [RunStats] -> JSON. Deterministic fields come from the fastest repeat;
+-- total_time_secs/gc_time_secs become {min, median, samples} instead of a
+-- single number.
+
+statsJSON :: [RunStats] -> JSON
+statsJSON stats =
+  let rs      = fastest stats
+      times   = map rsTotalTimeSecs stats
+      gcTimes = map rsGcTimeSecs stats
+  in JObject
+  [ ("runs", jInt (length stats))
+  , ("comb_file_size", jInt (rsCombFileSize rs))
+  , ("cells_at_start", jInt (rsCellsAtStart rs))
+  , ("heap_cells", jInt (rsHeapCells rs))
+  , ("heap_bytes", jInt (rsHeapBytes rs))
+  , ("cells_allocated", jInt (rsCellsAllocated rs))
+  , ("alloc_rate_mbps", jMaybe jDouble (rsAllocRateMBps rs))
+  , ("gcs", jInt (rsGCs rs))
+  , ("max_cells_used", jInt (rsMaxCellsUsed rs))
+  , ("reductions", jInt (rsReductions rs))
+  , ("reduction_rate_mps", jMaybe jDouble (rsReductionRateMps rs))
+  , ("yields", jInt (rsYields rs))
+  , ("resched", jInt (rsResched rs))
+  , ("array_alloc", jInt (rsArrayAlloc rs))
+  , ("array_free", jInt (rsArrayFree rs))
+  , ("foreign_alloc", jInt (rsForeignAlloc rs))
+  , ("foreign_free", jInt (rsForeignFree rs))
+  , ("bytestring_alloc", jInt (rsBytestringAlloc rs))
+  , ("bytestring_alloc_max", jInt (rsBytestringAllocMax rs))
+  , ("bytestring_alloc_bytes", jInt (rsBytestringAllocBytes rs))
+  , ("bytestring_alloc_bytes_max", jInt (rsBytestringAllocBytesMax rs))
+  , ("bytestring_free", jInt (rsBytestringFree rs))
+  , ("thread_create", jInt (rsThreadCreate rs))
+  , ("thread_reap", jInt (rsThreadReap rs))
+  , ("stableptr_alloc", jInt (rsStableptrAlloc rs))
+  , ("stableptr_free", jInt (rsStableptrFree rs))
+  , ("weakptr_alloc", jInt (rsWeakptrAlloc rs))
+  , ("weakptr_free", jInt (rsWeakptrFree rs))
+  , ("total_time_secs", timingJSON times)
+  , ("gc_time_secs", timingJSON gcTimes)
+  , ("gc_time_percent", jMaybe jDouble (rsGcTimePercent rs))
+  , ("gc_mark_time_secs", jDouble (rsGcMarkTimeSecs rs))
+  , ("gc_scan_time_secs", jDouble (rsGcScanTimeSecs rs))
+  , ("gc_reductions", jMaybe gcReductionsJSON (rsGCReductions rs))
+  , ("special_reductions", jMaybe specialReductionsJSON (rsSpecialReductions rs))
+  ]
+
+timingJSON :: [Double] -> JSON
+timingJSON samples = JObject
+  [ ("min", jDouble (minimum samples))
+  , ("median", jDouble (median samples))
+  , ("samples", JArray (map jDouble samples))
+  ]
+
+gcReductionsJSON :: GCReductions -> JSON
+gcReductionsJSON r = JObject
+  [ ("A", jInt (gcrA r)), ("K", jInt (gcrK r)), ("I", jInt (gcrI r))
+  , ("int", jInt (gcrInt r)), ("flip", jInt (gcrFlip r)), ("BI", jInt (gcrBI r))
+  , ("BxI", jInt (gcrBxI r)), ("C'BxI", jInt (gcrCcBxI r)), ("CC", jInt (gcrCC r))
+  , ("C'I", jInt (gcrCcI r)), ("C'BBCP", jInt (gcrCcBBCP r))
+  ]
+
+specialReductionsJSON :: SpecialReductions -> JSON
+specialReductionsJSON r = JObject
+  [ ("B'", jInt (srBprime r)), ("K4", jInt (srK4 r)), ("K3", jInt (srK3 r))
+  , ("K2", jInt (srK2 r)), ("C'B", jInt (srCcB r)), ("Z", jInt (srZ r)), ("R", jInt (srR r))
+  ]
+
+--------------------------------------------------------------------------
+-- Best-effort git metadata; harness still runs (with null commit/dirty
+-- fields) if git isn't available or this isn't a git checkout.
+
+getGitCommit :: IO (Maybe String)
+getGitCommit =
+  (Just . trim <$> readProcess "git" ["rev-parse", "HEAD"] "")
+  `catch` \(_ :: SomeException) -> return Nothing
+
+getGitDirty :: IO (Maybe Bool)
+getGitDirty =
+  (Just . not . null . trim <$> readProcess "git" ["status", "--porcelain"] "")
+  `catch` \(_ :: SomeException) -> return Nothing
+
+trim :: String -> String
+trim = dropWhileEnd isSpace . dropWhile isSpace

--- a/benchmarks/Util/Json.hs
+++ b/benchmarks/Util/Json.hs
@@ -1,0 +1,76 @@
+-- A minimal JSON value type and pretty-printer. We only need to emit JSON, never
+-- parse it.
+module Util.Json
+  ( JSON(..)
+  , jInt
+  , jDouble
+  , jString
+  , jMaybe
+  , renderJSON
+  ) where
+import Data.Char(ord)
+import Numeric(showHex)
+
+data JSON
+  = JNull
+  | JBool Bool
+  | JInt Integer
+  | JDouble Double
+  | JString String
+  | JArray [JSON]
+  | JObject [(String, JSON)]
+  deriving (Show, Eq)
+
+jInt :: Integral a => a -> JSON
+jInt = JInt . toInteger
+
+-- JSON has no representation for Infinity/NaN; the RTS stats print "inf"
+-- for a rate when the run was too short to divide by (see RunStats.hs), so
+-- that case becomes JSON null rather than an invalid number literal.
+jDouble :: Double -> JSON
+jDouble d = if isInfinite d || isNaN d then JNull else JDouble d
+
+jString :: String -> JSON
+jString = JString
+
+jMaybe :: (a -> JSON) -> Maybe a -> JSON
+jMaybe = maybe JNull
+
+--------------------------------------------------------------------------
+
+renderJSON :: JSON -> String
+renderJSON v = render 0 v ""
+
+-- Each render function takes an indent level and a continuation string to
+-- append (a difference-list style, so this stays linear in output size
+-- instead of repeatedly appending with (++)).
+render :: Int -> JSON -> ShowS
+render _ JNull        = showString "null"
+render _ (JBool b)    = showString (if b then "true" else "false")
+render _ (JInt n)     = shows n
+render _ (JDouble d)  = shows d
+render _ (JString s)  = renderString s
+render ind (JArray xs) = renderBlock ind '[' ']' (map (render (ind + 1)) xs)
+render ind (JObject kvs) =
+  renderBlock ind '{' '}' [ renderString k . showString ": " . render (ind + 1) v | (k, v) <- kvs ]
+
+renderBlock :: Int -> Char -> Char -> [ShowS] -> ShowS
+renderBlock _ open close [] = showChar open . showChar close
+renderBlock ind open close items =
+  showChar open . showChar '\n'
+  . foldr1 (\a b -> a . showString ",\n" . b) [ indent (ind + 1) . item | item <- items ]
+  . showChar '\n' . indent ind . showChar close
+  where indent n = showString (replicate (n * 2) ' ')
+
+renderString :: String -> ShowS
+renderString s = showChar '"' . foldr (\c k -> escape c . k) id s . showChar '"'
+  where
+    escape '"'  = showString "\\\""
+    escape '\\' = showString "\\\\"
+    escape '\n' = showString "\\n"
+    escape '\t' = showString "\\t"
+    escape '\r' = showString "\\r"
+    escape c
+      | ord c < 0x20 = showString "\\u" . showString (pad4 (showHex (ord c) ""))
+      | otherwise    = showChar c
+    pad4 h = replicate (4 - length h) '0' ++ h

--- a/benchmarks/Util/RunStats.hs
+++ b/benchmarks/Util/RunStats.hs
@@ -1,0 +1,286 @@
+-- Parses the text a benchmark prints when run with "+RTS -v -RTS" into a
+-- structured RunStats value. Deliberately hand-rolled (no Parsec): the
+-- format is a fixed set of "<number> <label>" lines (see the PRINT calls
+-- around src/runtime/eval.c:7240-7290), so a line-by-line classifier is
+-- simpler than a general parser combinator would be here.
+--
+-- The stats block shares stdout with whatever the benchmark itself
+-- printed, so parseRunStats scans every line of the whole capture and
+-- simply ignores lines it doesn't recognize; that also means the parser
+-- doesn't care where in the file the stats block starts, or in what
+-- order its lines appear.
+module Util.RunStats
+  ( RunStats(..)
+  , GCReductions(..)
+  , SpecialReductions(..)
+  , parseRunStats
+  ) where
+import Data.Char(isDigit, isSpace)
+import Data.List(stripPrefix)
+import Text.Read(readMaybe)
+
+data RunStats = RunStats
+  { rsCombFileSize            :: Integer
+  , rsCellsAtStart            :: Integer
+  , rsHeapCells               :: Integer
+  , rsHeapBytes               :: Integer
+  , rsCellsAllocated          :: Integer
+  , rsAllocRateMBps           :: Maybe Double  -- Nothing if the run was too short to divide by (prints "inf")
+  , rsGCs                     :: Integer
+  , rsMaxCellsUsed            :: Integer
+  , rsReductions              :: Integer
+  , rsReductionRateMps        :: Maybe Double
+  , rsYields                  :: Integer
+  , rsResched                 :: Integer
+  , rsArrayAlloc              :: Integer
+  , rsArrayFree               :: Integer
+  , rsForeignAlloc            :: Integer
+  , rsForeignFree             :: Integer
+  , rsBytestringAlloc         :: Integer
+  , rsBytestringAllocMax      :: Integer
+  , rsBytestringAllocBytes    :: Integer
+  , rsBytestringAllocBytesMax :: Integer
+  , rsBytestringFree          :: Integer
+  , rsThreadCreate            :: Integer
+  , rsThreadReap              :: Integer
+  , rsStableptrAlloc          :: Integer
+  , rsStableptrFree           :: Integer
+  , rsWeakptrAlloc            :: Integer
+  , rsWeakptrFree             :: Integer
+  , rsTotalTimeSecs           :: Double
+  , rsGcTimeSecs              :: Double
+  , rsGcTimePercent           :: Maybe Double
+  , rsGcMarkTimeSecs          :: Double
+  , rsGcScanTimeSecs          :: Double
+  , rsGCReductions            :: Maybe GCReductions       -- only present when the runtime is built with GCRED
+  , rsSpecialReductions       :: Maybe SpecialReductions  -- only present when the runtime is built with GCRED
+  }
+  deriving (Show, Eq)
+
+data GCReductions = GCReductions
+  { gcrA, gcrK, gcrI, gcrInt, gcrFlip, gcrBI, gcrBxI, gcrCcBxI, gcrCC, gcrCcI, gcrCcBBCP :: Integer
+  }
+  deriving (Show, Eq)
+
+data SpecialReductions = SpecialReductions
+  { srBprime, srK4, srK3, srK2, srCcB, srZ, srR :: Integer
+  }
+  deriving (Show, Eq)
+
+--------------------------------------------------------------------------
+-- Top level: scan every line, collect (key, value) contributions, then
+-- assemble the record by looking each field up by name.
+
+parseRunStats :: String -> Either String RunStats
+parseRunStats text = do
+  let contributions = map parseLine (lines text)
+      ints    = concatMap fst contributions
+      doubles = concatMap snd contributions
+      needInt k = maybe (Left ("RunStats: missing field " ++ show k)) Right (lookup k ints)
+      needDbl k = maybe (Left ("RunStats: missing field " ++ show k)) Right (lookup k doubles)
+      optInt k = lookup k ints
+      optDbl k = lookup k doubles
+  combFileSize    <- needInt "comb_file_size"
+  cellsAtStart    <- needInt "cells_at_start"
+  heapCells       <- needInt "heap_cells"
+  heapBytes       <- needInt "heap_bytes"
+  cellsAllocated  <- needInt "cells_allocated"
+  gcs             <- needInt "gcs"
+  maxCellsUsed    <- needInt "max_cells_used"
+  reductions      <- needInt "reductions"
+  yields          <- needInt "yields"
+  resched         <- needInt "resched"
+  arrayAlloc      <- needInt "array_alloc"
+  arrayFree       <- needInt "array_free"
+  foreignAlloc    <- needInt "foreign_alloc"
+  foreignFree     <- needInt "foreign_free"
+  bsAlloc         <- needInt "bytestring_alloc"
+  bsAllocMax      <- needInt "bytestring_alloc_max"
+  bsAllocBytes    <- needInt "bytestring_alloc_bytes"
+  bsAllocBytesMax <- needInt "bytestring_alloc_bytes_max"
+  bsFree          <- needInt "bytestring_free"
+  threadCreate    <- needInt "thread_create"
+  threadReap      <- needInt "thread_reap"
+  stableptrAlloc  <- needInt "stableptr_alloc"
+  stableptrFree   <- needInt "stableptr_free"
+  weakptrAlloc    <- needInt "weakptr_alloc"
+  weakptrFree     <- needInt "weakptr_free"
+  totalTime       <- needDbl "total_time_secs"
+  gcTime          <- needDbl "gc_time_secs"
+  gcMark          <- needDbl "gc_mark_secs"
+  gcScan          <- needDbl "gc_scan_secs"
+  let gcReds = do
+        a     <- optInt "A"
+        k     <- optInt "K"
+        i     <- optInt "I"
+        it    <- optInt "int"
+        fl    <- optInt "flip"
+        bi    <- optInt "BI"
+        bxi   <- optInt "BxI"
+        ccbxi <- optInt "C'BxI"
+        cc    <- optInt "CC"
+        cci   <- optInt "C'I"
+        ccbc  <- optInt "C'BBCP"
+        Just (GCReductions a k i it fl bi bxi ccbxi cc cci ccbc)
+      specReds = do
+        bp  <- optInt "B'"
+        k4  <- optInt "K4"
+        k3  <- optInt "K3"
+        k2  <- optInt "K2"
+        ccb <- optInt "C'B"
+        z   <- optInt "Z"
+        r   <- optInt "R"
+        Just (SpecialReductions bp k4 k3 k2 ccb z r)
+  return RunStats
+    { rsCombFileSize            = combFileSize
+    , rsCellsAtStart            = cellsAtStart
+    , rsHeapCells               = heapCells
+    , rsHeapBytes               = heapBytes
+    , rsCellsAllocated          = cellsAllocated
+    , rsAllocRateMBps           = optDbl "alloc_rate_mbps"
+    , rsGCs                     = gcs
+    , rsMaxCellsUsed            = maxCellsUsed
+    , rsReductions              = reductions
+    , rsReductionRateMps        = optDbl "reduction_rate_mps"
+    , rsYields                  = yields
+    , rsResched                 = resched
+    , rsArrayAlloc              = arrayAlloc
+    , rsArrayFree               = arrayFree
+    , rsForeignAlloc            = foreignAlloc
+    , rsForeignFree             = foreignFree
+    , rsBytestringAlloc         = bsAlloc
+    , rsBytestringAllocMax      = bsAllocMax
+    , rsBytestringAllocBytes    = bsAllocBytes
+    , rsBytestringAllocBytesMax = bsAllocBytesMax
+    , rsBytestringFree          = bsFree
+    , rsThreadCreate            = threadCreate
+    , rsThreadReap              = threadReap
+    , rsStableptrAlloc          = stableptrAlloc
+    , rsStableptrFree           = stableptrFree
+    , rsWeakptrAlloc            = weakptrAlloc
+    , rsWeakptrFree             = weakptrFree
+    , rsTotalTimeSecs           = totalTime
+    , rsGcTimeSecs              = gcTime
+    , rsGcTimePercent           = optDbl "gc_time_percent"
+    , rsGcMarkTimeSecs          = gcMark
+    , rsGcScanTimeSecs          = gcScan
+    , rsGCReductions            = gcReds
+    , rsSpecialReductions       = specReds
+    }
+
+--------------------------------------------------------------------------
+-- Per-line classification. Every recognized line contributes zero or more
+-- (key, value) pairs; unrecognized lines (the benchmark's own output)
+-- contribute nothing.
+
+parseLine :: String -> ([(String, Integer)], [(String, Double)])
+parseLine raw =
+  let line = dropWhile isSpace raw
+  in case tryTotalTime line of
+       Just t -> ([], [("total_time_secs", t)])
+       Nothing -> case tryGcTime line of
+         Just (gcSecs, pct, markSecs, scanSecs) ->
+           ( []
+           , [("gc_time_secs", gcSecs), ("gc_mark_secs", markSecs), ("gc_scan_secs", scanSecs)]
+             ++ maybe [] (\p -> [("gc_time_percent", p)]) pct
+           )
+         Nothing -> case tryKVLine "GC reductions " line of
+           Just kvs -> (kvs, [])
+           Nothing -> case tryKVLine "special reductions " line of
+             Just kvs -> (kvs, [])
+             Nothing -> case numPrefix line of
+               Just (n, rest) -> classifyNumberedLine n rest
+               Nothing        -> ([], [])
+
+-- "<int> <label...>" lines, e.g. "         31108 combinator file size" or
+-- "       50000000 cells heap size (800000000 bytes)".
+classifyNumberedLine :: Integer -> String -> ([(String, Integer)], [(String, Double)])
+classifyNumberedLine n rest
+  | rest == "combinator file size" = ([("comb_file_size", n)], [])
+  | rest == "cells at start"       = ([("cells_at_start", n)], [])
+  | Just tl <- stripPrefix "cells heap size (" rest
+      = ([("heap_cells", n)] ++ intField "heap_bytes" tl, [])
+  | Just tl <- stripPrefix "cells allocated (" rest
+      = ([("cells_allocated", n)], rateField "alloc_rate_mbps" tl)
+  | rest == "GCs"                  = ([("gcs", n)], [])
+  | rest == "max cells used"       = ([("max_cells_used", n)], [])
+  | Just tl <- stripPrefix "reductions (" rest
+      = ([("reductions", n)], rateField "reduction_rate_mps" tl)
+  | Just tl <- stripPrefix "yields (" rest
+      = ([("yields", n)] ++ intField "resched" tl, [])
+  | rest == "array alloc"          = ([("array_alloc", n)], [])
+  | rest == "array free"           = ([("array_free", n)], [])
+  | rest == "foreign alloc"        = ([("foreign_alloc", n)], [])
+  | rest == "foreign free"         = ([("foreign_free", n)], [])
+  | Just tl <- stripPrefix "bytestring alloc bytes (max " rest
+      = ([("bytestring_alloc_bytes", n)] ++ intField "bytestring_alloc_bytes_max" tl, [])
+  | Just tl <- stripPrefix "bytestring alloc (max " rest
+      = ([("bytestring_alloc", n)] ++ intField "bytestring_alloc_max" tl, [])
+  | rest == "bytestring free"      = ([("bytestring_free", n)], [])
+  | rest == "thread create"        = ([("thread_create", n)], [])
+  | rest == "thread reap"          = ([("thread_reap", n)], [])
+  | rest == "stableptr alloc"      = ([("stableptr_alloc", n)], [])
+  | rest == "stableptr free"       = ([("stableptr_free", n)], [])
+  | rest == "weakptr alloc"        = ([("weakptr_alloc", n)], [])
+  | rest == "weakptr free"         = ([("weakptr_free", n)], [])
+  | otherwise                      = ([], [])
+  where
+    intField key s = maybe [] (\v -> [(key, v)]) (readMaybe (takeWhile isDigit s))
+    rateField key s = maybe [] (\v -> [(key, v)]) (parseRate (takeWhile (/= ' ') s))
+
+-- The number (with optional ',' thousands separators) at the start of a
+-- line, and everything after it with leading spaces dropped.
+numPrefix :: String -> Maybe (Integer, String)
+numPrefix s =
+  let (digitsPart, rest) = span (\c -> isDigit c || c == ',') s
+      cleaned = filter (/= ',') digitsPart
+  in if null cleaned then Nothing else fmap (\v -> (v, dropWhile isSpace rest)) (readMaybe cleaned)
+
+-- A leading floating-point literal (mhs prints these with a plain '.',
+-- never scientific notation) and the rest of the string.
+takeFloat :: String -> Maybe (Double, String)
+takeFloat s =
+  let (numPart, rest) = span (\c -> isDigit c || c == '.') s
+  in if null numPart then Nothing else fmap (\v -> (v, rest)) (readMaybe numPart)
+
+-- Rates can print as "inf" when the run is too short to divide by (see
+-- num_alloc * NODE_SIZE / (run_time / 1000) at src/runtime/eval.c:7248).
+parseRate :: String -> Maybe Double
+parseRate "inf" = Just (1 / 0)
+parseRate s     = readMaybe s
+
+-- "2.03s total expired time"
+tryTotalTime :: String -> Maybe Double
+tryTotalTime line = do
+  (secs, r1) <- takeFloat line
+  r2 <- stripPrefix "s" r1
+  if dropWhile isSpace r2 == "total expired time" then Just secs else Nothing
+
+-- "0.00s gc expired time = 0.1% (0.00s mark + 0.00s scan)"
+tryGcTime :: String -> Maybe (Double, Maybe Double, Double, Double)
+tryGcTime line = do
+  (gcSecs, r1) <- takeFloat line
+  r2 <- stripPrefix "s" r1
+  r3 <- stripPrefix "gc expired time = " (dropWhile isSpace r2)
+  let (pctTok, r4) = span (/= '%') r3
+  r5 <- stripPrefix "%" r4
+  r6 <- stripPrefix "(" (dropWhile isSpace r5)
+  (markSecs, r7) <- takeFloat r6
+  r8 <- stripPrefix "s mark + " r7
+  (scanSecs, r9) <- takeFloat r8
+  _ <- stripPrefix "s scan)" r9
+  return (gcSecs, parseRate pctTok, markSecs, scanSecs)
+
+-- " GC reductions A=405, K=13, ..." / " special reductions B'=0 K4=0 ..."
+-- Separators are an inconsistent mix of ", " and " " in the C format
+-- string, so commas are normalized to spaces before splitting on
+-- whitespace, then each "key=value" token is split on '='.
+tryKVLine :: String -> String -> Maybe [(String, Integer)]
+tryKVLine label line = do
+  rest <- stripPrefix label line
+  let cleaned = map (\c -> if c == ',' then ' ' else c) rest
+      toks    = words cleaned
+  Just [ (k, v) | tok <- toks
+                , let (k, eqv) = break (== '=') tok
+                , not (null eqv)
+                , Just v <- [readMaybe (drop 1 eqv)] ]


### PR DESCRIPTION
A proposal for some simple benchmarking machinery, to track how changes to the compiler or runtime affect the runtime behavior of MicroHs. I asked a Clanker for the code that parses the `+RTS -v -RTS` output.

If you issue `make bench`, it will build the sample benchmark programs included here, and then execute them. It will run each five times (override-able) to gather multiple GC times and execution times. The reduction count, allocation counts, etc, all appear to be deterministic, and are gathered only once. The result is written to a JSON file, named via the current Unix timestamp.

The idea is perhaps that some software yet to be written can read the JSON and render is nicely or something, but I have not written such a software. I've proposed some initial sample benchmarks, intended to exercise different things, but this is by no means exhaustive.

This is a proposal, and I am happy to hear what you think.