### PR TITLE
prefetch in mark

### DIFF
--- a/src/runtime/eval.c
+++ b/src/runtime/eval.c
@@ -684,6 +684,13 @@ static INLINE void SETTAG(NODEPTR p, tag_t t)
 #define LABEL(n) ((heapoffs_t)((n) - cells))
 node *cells;                 /* All cells */
 
+/* Prefetch a node we know we'll need soon but haven't dereferenced yet. */
+#if defined(__GNUC__) || defined(__clang__)
+#define PREFETCH_READ(addr) __builtin_prefetch((addr), 0, 2)
+#else
+#define PREFETCH_READ(addr) do { } while(0)
+#endif
+
 /*
  * Byte arrays.
  * This is used for both immutable and mutable arrays.
@@ -2993,6 +3000,7 @@ mark(NODEPTR *np)
 
   if (!is_marked_used(*to_push)) {
     //  mark_depth++;
+    PREFETCH_READ(*to_push);   /* won't be popped and dereferenced until later */
     PUSH((NODEPTR)to_push);
   }
   goto top;


### PR DESCRIPTION
Prefetching in `mark` gave me some mixed results, but generally good ones I think. A majority of my cache misses were in `mark`, which is not surprising as it is quite chaotic. However, it does push nodes to a stack in order to visit them later, and by prefetching a node when it is pushed, I get fewer cache misses.

When compiling the compiler as the benchmark, I get 31% fewer cache misses, and my average runtime (over 5 runs) goes from 70.5 seconds to 66 seconds. The time spent marking nodes goes from 10.8 to 7.4 seconds.

However, when I test the change against the benchmarks mentioned in pr #515 , I get some more mixed results. The below percentages are the differences in absolute execution times, averaged over five runs.

NFib - +7.5%
FibTail - +3.4%
FibInt - +3.5%
NumericIntegration - +2.5%
TightIntLoop - +2.5%
ListFusion - +1.6%
FibInteger - +1.2%
PrimeSieve - +0.8%
MergeSort - -0.8%
ForkJoin - -0.8%
ExprVal - -0.4%

They are microbenchmarks, and don't run for as long. Additionally, the behavior of `mark` is naturally tightly related to the live node set, the allocation rate, etc etc. This differs between all these programs.